### PR TITLE
fix: Add ERPNext to Healthcare.required_apps

### DIFF
--- a/healthcare/hooks.py
+++ b/healthcare/hooks.py
@@ -11,6 +11,8 @@ app_color = "grey"
 app_email = "contact@frappe.io"
 app_license = "MIT"
 
+required_apps = ["erpnext"]
+
 # Includes in <head>
 # ------------------
 


### PR DESCRIPTION
Healthcare requires ERPNext to be installed on the site before itself. Adding this makes sure erpnext is installed prior to healthcare. 

I'm working on utilizing this to resolve bench dependencies in a similar fashion. For now, this enables the install on a site level.

Ref: https://github.com/frappe/frappe/blob/9f0fe09e0002412549d35791620e135a5a6f245f/frappe/installer.py#L122-L138