### PR TITLE
fix: Include dosage form in medications grid view

### DIFF
--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -11,7 +11,8 @@ frappe.ui.form.on('Patient Encounter', {
 			{fieldname: 'drug_code', columns: 2},
 			{fieldname: 'drug_name', columns: 2},
 			{fieldname: 'dosage', columns: 2},
-			{fieldname: 'period', columns: 2}
+			{fieldname: 'period', columns: 2},
+			{fieldname: 'dosage_form', columns: 2}
 		];
 		frm.get_field('lab_test_prescription').grid.editable_fields = [
 			{fieldname: 'lab_test_code', columns: 2},


### PR DESCRIPTION
Dosage form field is mandatory but it is not shown in grid view which is causing a bad UX. Added it to grid view.

<img width="1276" alt="Screenshot 2021-10-21 at 17 25 15" src="https://user-images.githubusercontent.com/4463796/138272480-5fc2ada1-1e31-415c-a191-2b24516361c6.png">
