### PR TITLE
fix: Preserve existing items in invoice when new items are added

### DIFF
--- a/healthcare/healthcare/custom_doctype/sales_invoice.py
+++ b/healthcare/healthcare/custom_doctype/sales_invoice.py
@@ -6,7 +6,6 @@ from erpnext.accounts.doctype.sales_invoice.sales_invoice import SalesInvoice
 class HealthcareSalesInvoice(SalesInvoice):
 	@frappe.whitelist()
 	def set_healthcare_services(self, checked_values):
-		self.set("items", [])
 		from erpnext.stock.get_item_details import get_item_details
 		for checked_item in checked_values:
 			item_line = self.append("items", {})

--- a/healthcare/healthcare/custom_doctype/test_sales_invoice.py
+++ b/healthcare/healthcare/custom_doctype/test_sales_invoice.py
@@ -1,0 +1,27 @@
+import frappe
+from erpnext.tests.utils import ERPNextTestCase
+
+test_records = frappe.get_test_records('Sales Invoice')
+
+
+class TestSalesInvoice(ERPNextTestCase):
+	def test_set_healthcare_services_should_preserve_state(self):
+		invoice = frappe.copy_doc(test_records[0])
+
+		count = len(invoice.items)
+		item = invoice.items[0]
+		checked_values = [{
+			'dt': 'Item',
+			'dn': item.item_name,
+			'item': item.item_code,
+			'qty': False,
+			'rate': False,
+			'income_account': False,
+			'description': False,
+		}]
+
+		invoice.set_healthcare_services(checked_values)
+		self.assertEqual(count + 1, len(invoice.items))
+
+		invoice.set_healthcare_services(checked_values)
+		self.assertEqual(count + 2, len(invoice.items))

--- a/healthcare/public/js/sales_invoice.js
+++ b/healthcare/public/js/sales_invoice.js
@@ -109,7 +109,6 @@ var set_primary_action= function(frm, dialog, $results, invoice_healthcare_servi
 			if(invoice_healthcare_services) {
 				frm.set_value("patient", dialog.fields_dict.patient.input.value);
 			}
-			frm.set_value("items", []);
 			add_to_item_line(frm, checked_values, invoice_healthcare_services);
 			dialog.hide();
 		}


### PR DESCRIPTION
Currently, when items are added from "Healthcare services" in sales invoice, existing items are cleared.

<img width="1279" alt="Screenshot 2021-11-09 at 16 05 07" src="https://user-images.githubusercontent.com/4463796/140908846-f7573cd2-e4ad-4a9a-92cd-93df1857d6d6.png">


Since users can add items multiple times, existing items should be preserved in the invoice. 