### PR TITLE
fix: Add validation for sample quantity in lab test template

### DIFF
--- a/healthcare/healthcare/doctype/lab_test_template/lab_test_template.py
+++ b/healthcare/healthcare/doctype/lab_test_template/lab_test_template.py
@@ -10,6 +10,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.model.rename_doc import rename_doc
+from frappe.utils import flt
 
 
 class LabTestTemplate(Document):
@@ -20,6 +21,9 @@ class LabTestTemplate(Document):
 	def validate(self):
 		if self.is_billable and (not self.lab_test_rate or self.lab_test_rate <= 0.0):
 			frappe.throw(_('Standard Selling Rate should be greater than zero.'))
+
+		if self.sample and flt(self.sample_qty) <= 0:
+			frappe.throw(_('Sample Quantity cannot be negative or 0'), title=_('Invalid Quantity'))
 
 		self.validate_conversion_factor()
 		self.enable_disable_item()


### PR DESCRIPTION
When user is creating a lab test, it is throwing this error. This is happening as lab test template doesn't have quantity.

<img width="1274" alt="Screenshot 2021-11-25 at 16 38 07" src="https://user-images.githubusercontent.com/4463796/143430999-5b33ccbf-3c4d-4c30-97af-3cca657a4ee9.png">


Added validation for sample quantity in lab test template itself. 