### PR TITLE
fix: Allow duplication in patient appointment doctype

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "allow_copy": 1,
+ "allow_copy": 0,
  "allow_import": 1,
  "autoname": "naming_series:",
  "beta": 1,
@@ -349,7 +349,7 @@
   }
  ],
  "links": [],
- "modified": "2021-08-30 09:00:41.329387",
+ "modified": "2022-02-14 09:00:41.329387",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Patient Appointment",


### PR DESCRIPTION
Ref https://github.com/frappe/healthcare/issues/31

Currently, to create follow up appointments, users have to enter all the details again. Instead of we allow "duplicate" option, users can use current appointment to create follow up appointments if required. 

Closes https://github.com/frappe/healthcare/issues/31