### PR TITLE
feat: Add connection to inpatient record from service unit

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_service_unit/healthcare_service_unit_dashboard.py
+++ b/healthcare/healthcare/doctype/healthcare_service_unit/healthcare_service_unit_dashboard.py
@@ -1,0 +1,12 @@
+def get_data():
+	return {
+		'fieldname': 'service_unit',
+		'internal_links': {
+			'Inpatient Occupancy': ['inpatient_occupancies']
+		},
+		'transactions': [
+			{
+				'items': ['Inpatient Record']
+			}
+		]
+	}


### PR DESCRIPTION
From service unit, there is option to navigate to inpatient record list. 

Adding a connection to inpatient record will be useful to quickly see patient details, admission/discharge date etc.

<img width="1280" alt="Screenshot 2022-02-21 at 16 21 40" src="https://user-images.githubusercontent.com/4463796/154941329-7d877f7a-ee81-49c8-8a29-5ae2cded4b57.png">
