### PR TITLE
fix: Hide "Add Inpatient Record" button in list view

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record_list.js
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record_list.js
@@ -1,0 +1,5 @@
+frappe.listview_settings['Inpatient Record'] = {
+	onload: function (listview) {
+	    $('.btn-primary').hide();
+	}
+};


### PR DESCRIPTION
Currently, patients are scheduled for admission via encounter. We have disabled option to create entries directly from inpatient record. 

<img width="1200" alt="Screenshot 2022-03-21 at 17 34 57" src="https://user-images.githubusercontent.com/4463796/159302381-67ded7aa-7645-44f7-b536-f73993aa9ae2.png">


Removing `Add Inpatient Record` button to avoid confusion.

<img width="1200" alt="Screenshot 2022-03-21 at 17 35 06" src="https://user-images.githubusercontent.com/4463796/159302419-a32e6744-355c-4206-90b8-6d2e2c2bc389.png">

There are other doctypes in Frappe/ERPNext where the same issue is present. May be we can clean them up separately or have an option at doctype level to hide this button. 

Refer https://github.com/frappe/frappe/issues/16367