### PR TITLE
feat(patient-appointment): today as a min date in check availability

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -306,7 +306,7 @@ let check_and_set_availability = function(frm) {
 				{ fieldtype: 'Column Break' },
 				{ fieldtype: 'Link', options: 'Healthcare Practitioner', reqd: 1, fieldname: 'practitioner', label: 'Healthcare Practitioner' },
 				{ fieldtype: 'Column Break' },
-				{ fieldtype: 'Date', reqd: 1, fieldname: 'appointment_date', label: 'Date' },
+				{ fieldtype: 'Date', reqd: 1, fieldname: 'appointment_date', label: 'Date', min_date: new Date(frappe.datetime.get_today()) },
 				{ fieldtype: 'Section Break' },
 				{ fieldtype: 'HTML', fieldname: 'available_slots' }
 


### PR DESCRIPTION
When clicking on _Check Availability_ button on new _Patient Appointment_, in the field _Date_, allows to choose a date in an interval from today or above. 
It has no logic to create an appointment for yesterday or passed days. This will increase user experience, and avoid prone errors.
 _![date](https://user-images.githubusercontent.com/963110/173193228-61f81205-aeac-4913-8518-2eb8dd2df4e2.png)_