### PR TITLE
fix: Check for employee doctype in hr & setup

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -23,7 +23,11 @@ from healthcare.healthcare.utils import (
 	get_service_item_and_practitioner_charge,
 	manage_fee_validity,
 )
-from erpnext.hr.doctype.employee.employee import is_holiday
+# todo: clean up imports
+try:
+	from erpnext.hr.doctype.employee.employee import is_holiday
+except ImportError:
+	from erpnext.setup.doctype.employee.employee import is_holiday
 
 
 class MaximumCapacityError(frappe.ValidationError):


### PR DESCRIPTION
Since HR app is seperated from ERPNext, we will have compatible imports for now.

This should be cleaned up later.