### PR TITLE
feat: Create root service units for all companies by default

### DIFF
--- a/healthcare/setup.py
+++ b/healthcare/setup.py
@@ -79,6 +79,15 @@ def setup_healthcare():
 		# already setup
 		return
 	create_custom_records()
+	create_default_root_service_units()
+
+
+def create_default_root_service_units():
+	from healthcare.healthcare.utils import create_healthcare_service_unit_tree_root
+
+	companies = frappe.get_all('Company')
+	for company in companies:
+		create_healthcare_service_unit_tree_root(company)
 
 
 def create_custom_records():


### PR DESCRIPTION
When app is freshly installed on a site, FH app should create default root service units.

Related: https://github.com/frappe/health/issues/118