### PR TITLE
fix: not able to invoke whitelisted static method

### DIFF
--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.py
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.py
@@ -34,8 +34,8 @@ class PatientEncounter(Document):
 			self.patient_name or self.patient, self.practitioner_name or self.practitioner
 		)[:100]
 
-	@frappe.whitelist()
 	@staticmethod
+	@frappe.whitelist()
 	def get_applicable_treatment_plans(encounter):
 		patient = frappe.get_doc("Patient", encounter["patient"])
 


### PR DESCRIPTION
Quick fix to close https://github.com/frappe/health/issues/174 recommended in this [post](https://blog.peterlamut.com/tag/classmethod) by Peter Lamut.

@ankush excuse me for tagging here, but thought you would like to take a look as this was not the case before recently introducing typing_validations. I'm sure frappe should handle this better, and as the blog post says [Wrapt](https://github.com/GrahamDumpleton/wrapt) seem to help handle decorators "correctly" ;)

If I'm missing something please suggest, thanks!