### PR TITLE
fix: allow delete root service unit if deleting company

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_service_unit/healthcare_service_unit.py
+++ b/healthcare/healthcare/doctype/healthcare_service_unit/healthcare_service_unit.py
@@ -29,6 +29,12 @@ class HealthcareServiceUnit(NestedSet):
 		super(HealthcareServiceUnit, self).on_update()
 		self.validate_one_root()
 
+	def on_trash(self):
+		if self.flags.on_trash_company:
+			NestedSet.on_trash(self, allow_root_deletion=True)
+		else:
+			NestedSet.on_trash(self)
+
 	def set_service_unit_properties(self):
 		if cint(self.is_group):
 			self.allow_appointments = False

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -979,3 +979,10 @@ def get_medical_codes(template_dt, template_dn, code_standard=None):
 			"medical_code_standard",
 		],
 	)
+
+
+def company_on_trash(doc, method):
+	for su in frappe.get_all("Healthcare Service Unit", {"company": doc.name}):
+		service_unit_doc = frappe.get_doc("Healthcare Service Unit", su.get("name"))
+		service_unit_doc.flags.on_trash_company = True
+		service_unit_doc.delete()

--- a/healthcare/hooks.py
+++ b/healthcare/hooks.py
@@ -112,7 +112,8 @@ doc_events = {
 		"on_cancel": "healthcare.healthcare.utils.manage_invoice_submit_cancel",
 	},
 	"Company": {
-		"after_insert": "healthcare.healthcare.utils.create_healthcare_service_unit_tree_root"
+		"after_insert": "healthcare.healthcare.utils.create_healthcare_service_unit_tree_root",
+		"on_trash": "healthcare.healthcare.utils.company_on_trash",
 	},
 	"Patient": {
 		"after_insert": "healthcare.regional.india.abdm.utils.set_consent_attachment_details"


### PR DESCRIPTION
Issue: Not able to delete Company as NestedSet root node cannot be deleted 

![company_delete](https://user-images.githubusercontent.com/48046415/222666593-bb6faeeb-7e54-468b-89c2-ced762915a8d.png)
