### PR TITLE
fix: reset portal settings after uninstall

### DIFF
--- a/healthcare/hooks.py
+++ b/healthcare/hooks.py
@@ -75,7 +75,7 @@ after_install = "healthcare.setup.setup_healthcare"
 # ------------
 
 before_uninstall = "healthcare.uninstall.before_uninstall"
-# after_uninstall = "healthcare.uninstall.after_uninstall"
+after_uninstall = "healthcare.uninstall.after_uninstall"
 
 # Desk Notifications
 # ------------------

--- a/healthcare/uninstall.py
+++ b/healthcare/uninstall.py
@@ -1,4 +1,5 @@
 import click
+import frappe
 
 from healthcare.setup import before_uninstall as remove_customizations
 
@@ -19,3 +20,8 @@ def before_uninstall():
 		raise e
 
 	click.secho("Frappe Health app customizations have been removed successfully...", fg="green")
+
+
+def after_uninstall():
+	print("Reset Portal Settings...")
+	frappe.get_doc("Portal Settings", "Portal Settings").reset()


### PR DESCRIPTION
deleting menu from Portal Settings messes up child table idx