### PR TITLE
fix(patch): check_version_compatibility_with_frappe

### DIFF
--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -1,2 +1,3 @@
 healthcare.patches.v0_0.setup_abdm_custom_fields
 healthcare.patches.v0_0.set_medical_code_from_field_to_codification_table
+healthcare.patches.v15_0.check_version_compatibility_with_frappe

--- a/healthcare/patches/v15_0/check_version_compatibility_with_frappe.py
+++ b/healthcare/patches/v15_0/check_version_compatibility_with_frappe.py
@@ -1,0 +1,19 @@
+import click
+import frappe
+
+
+def execute():
+	frappe_v = frappe.get_attr("frappe" + ".__version__")
+	healthcare_v = frappe.get_attr("healthcare" + ".__version__")
+
+	WIKI_URL = "https://github.com/frappe/health/wiki/changes-to-branching-and-versioning"
+
+	if frappe_v.startswith("14") and healthcare_v.startswith("15"):
+		message = f"""
+			The `develop` branch of Frappe Health is no longer compatible with Frappe & ERPNext's `version-14`.
+			Since you are using ERPNext/Frappe `version-14` please switch Frappe Health app's branch to `version-14` and then proceed with the update.\n\t
+			You can switch the branch by following the steps mentioned here: {WIKI_URL}
+		"""
+		click.secho(message, fg="red")
+
+		frappe.throw(message)  # nosemgrep


### PR DESCRIPTION
patch to stop migration and prompt to switch the branch to `version-14` if the site's frappe branch is `version-14` and frappe health branch is `develop`