### PR TITLE
fix: exercises not set in Therapy Session when creating from Therapy Plan

### DIFF
--- a/healthcare/healthcare/doctype/therapy_plan/therapy_plan.py
+++ b/healthcare/healthcare/doctype/therapy_plan/therapy_plan.py
@@ -64,7 +64,12 @@ def make_therapy_session(therapy_plan, patient, therapy_type, company, appointme
 	therapy_session.therapy_type = therapy_type.name
 	therapy_session.duration = therapy_type.default_duration
 	therapy_session.rate = therapy_type.rate
-	therapy_session.exercises = therapy_type.exercises
+	if not therapy_session.exercises and therapy_type.exercises:
+		for exercise in therapy_type.exercises:
+			therapy_session.append(
+				"exercises",
+				(frappe.copy_doc(exercise)).as_dict(),
+			)
 	therapy_session.appointment = appointment
 
 	if frappe.flags.in_test:

--- a/healthcare/healthcare/doctype/therapy_session/test_therapy_session.py
+++ b/healthcare/healthcare/doctype/therapy_session/test_therapy_session.py
@@ -7,9 +7,19 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import nowdate
 
+from healthcare.healthcare.doctype.therapy_plan.test_therapy_plan import create_therapy_plan
+
 
 class TestTherapySession(FrappeTestCase):
-	pass
+	def test_exercise_set_from_therapy_type(self):
+		plan = create_therapy_plan()
+		session = create_therapy_session(plan.patient, "Basic Rehab", plan.name)
+		if plan.therapy_plan_details:
+			therapy_type = frappe.get_doc("Therapy Type", plan.therapy_plan_details[0].therapy_type)
+			self.assertEqual(
+				session.exercises[0].exercise_type,
+				therapy_type.exercises[0].exercise_type,
+			)
 
 
 def create_therapy_session(patient, therapy_type, therapy_plan, duration=0, start_date=None):

--- a/healthcare/healthcare/doctype/therapy_session/therapy_session.py
+++ b/healthcare/healthcare/doctype/therapy_session/therapy_session.py
@@ -21,6 +21,7 @@ from healthcare.healthcare.utils import validate_nursing_tasks
 
 class TherapySession(Document):
 	def validate(self):
+		self.set_exercises_from_therapy_type()
 		self.validate_duplicate()
 		self.set_total_counts()
 
@@ -109,6 +110,16 @@ class TherapySession(Document):
 
 		self.db_set("total_counts_targeted", target_total)
 		self.db_set("total_counts_completed", counts_completed)
+
+	def set_exercises_from_therapy_type(self):
+		if self.therapy_type and not self.exercises:
+			therapy_type_doc = frappe.get_cached_doc("Therapy Type", self.therapy_type)
+			if therapy_type_doc.exercises:
+				for exercise in therapy_type_doc.exercises:
+					self.append(
+						"exercises",
+						(frappe.copy_doc(exercise)).as_dict(),
+					)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
- Add exercises in Therapy Session - on creating via quick entry from Therapy Plan
- Fix exercises table getting copied from Therapy Type (including name) - on creating via custom button from Therapy Plan