### PR TITLE
fix: Get Applicable Treatment Plan for new Patient Encounter

### DIFF
--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -249,10 +249,8 @@ frappe.ui.form.on('Patient Encounter', {
 							doc: frm.doc,
 							args: selections,
 						}).then(() => {
-							frm.refresh_field('drug_prescription');
-							frm.refresh_field('procedure_prescription');
-							frm.refresh_field('lab_test_prescription');
-							frm.refresh_field('therapies');
+							frm.refresh_fields();
+							frm.dirty();
 						});
 						cur_dialog.hide();
 					}

--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.py
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.py
@@ -97,8 +97,6 @@ class PatientEncounter(Document):
 		for drug in plan_doc.drugs:
 			self.append("drug_prescription", (frappe.copy_doc(drug)).as_dict())
 
-		self.save()
-
 	def set_treatment_plan_item(self, plan_item):
 		if plan_item.type == "Clinical Procedure Template":
 			self.append("procedure_prescription", {"procedure": plan_item.template})
@@ -107,7 +105,10 @@ class PatientEncounter(Document):
 			self.append("lab_test_prescription", {"lab_test_code": plan_item.template})
 
 		if plan_item.type == "Therapy Type":
-			self.append("therapies", {"therapy_type": plan_item.template})
+			self.append(
+				"therapies",
+				{"therapy_type": plan_item.template, "no_of_sessions": plan_item.qty},
+			)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Issues:
 - Get Applicable Treatment Plan not working on new Patient Encounter (before save)
 - set number of therapy sessions when ordering therapy type in Encounter

closes https://github.com/frappe/health/issues/150