### PR TITLE
fix: Include dosage form in grid view

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
@@ -7,7 +7,8 @@ frappe.ui.form.on('Inpatient Record', {
 			{fieldname: 'drug_code', columns: 2},
 			{fieldname: 'drug_name', columns: 2},
 			{fieldname: 'dosage', columns: 2},
-			{fieldname: 'period', columns: 2}
+			{fieldname: 'period', columns: 2},
+			{fieldname: 'dosage_form', columns: 2}
 		];
 	},
 	refresh: function(frm) {


### PR DESCRIPTION
Currently, the dosage form is not in the grid view for inpatient medications. This is causing a bad UX. Since it is a mandatory field, it should be shown in the grid view as well.

<img width="1273" alt="Screenshot 2023-04-18 at 07 55 31" src="https://user-images.githubusercontent.com/4463796/232654082-d9a07494-9408-4f9f-bc69-3b38d9501219.png">

