### PR TITLE
fix: Make service unit type mandatory for service unit

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_service_unit/healthcare_service_unit.js
+++ b/healthcare/healthcare/doctype/healthcare_service_unit/healthcare_service_unit.js
@@ -26,7 +26,6 @@ frappe.ui.form.on('Healthcare Service Unit', {
 		}
 
 		frm.trigger('set_root_readonly');
-		frm.set_df_property('service_unit_type', 'reqd', 1);
 		frm.add_custom_button(__('Healthcare Service Unit Tree'), function() {
 			frappe.set_route('Tree', 'Healthcare Service Unit');
 		});

--- a/healthcare/healthcare/doctype/healthcare_service_unit/healthcare_service_unit.json
+++ b/healthcare/healthcare/doctype/healthcare_service_unit/healthcare_service_unit.json
@@ -72,6 +72,7 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Service Unit Type",
+   "reqd": 1,
    "options": "Healthcare Service Unit Type"
   },
   {


### PR DESCRIPTION
In the service unit full form, unit type is mandatory but in the quick form, it is not. 