### PR TITLE
fix(patient_appointment):cancel_sales_invoice

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -4,7 +4,7 @@ set -ex
 
 cd ~ || exit
 
-sudo apt-get install redis-server libcups2-dev -qq
+sudo apt-get update && sudo apt-get install redis-server libcups2-dev --fix-missing
 
 pip install frappe-bench
 

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -418,8 +418,9 @@ def cancel_appointment(appointment_id):
 def cancel_sales_invoice(sales_invoice):
 	if frappe.db.get_single_value("Healthcare Settings", "automate_appointment_invoicing"):
 		if len(sales_invoice.items) == 1:
-			sales_invoice.cancel()
-			return True
+			if sales_invoice.docstatus == 1:
+				sales_invoice.cancel()
+				return True
 	return False
 
 

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -419,8 +419,14 @@ def cancel_sales_invoice(sales_invoice):
 	if frappe.db.get_single_value("Healthcare Settings", "automate_appointment_invoicing"):
 		if len(sales_invoice.items) == 1:
 			if sales_invoice.docstatus == 1:
-				sales_invoice.cancel()
-				return True
+				frappe.throw(
+				_(
+					"The Sales Invoice {0} is Draft you cant cancel."
+				).format(
+					get_link_to_form("Sales Invoice", sales_invoice)
+				)
+			)
+			return True
 	return False
 
 

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -418,14 +418,8 @@ def cancel_appointment(appointment_id):
 def cancel_sales_invoice(sales_invoice):
 	if frappe.db.get_single_value("Healthcare Settings", "automate_appointment_invoicing"):
 		if len(sales_invoice.items) == 1:
-			if sales_invoice.docstatus == 1:
-				frappe.throw(
-				_(
-					"The Sales Invoice {0} is Draft you cant cancel."
-				).format(
-					get_link_to_form("Sales Invoice", sales_invoice)
-				)
-			)
+			if sales_invoice.docstatus.is_submitted():
+				sales_invoice.cancel()
 			return True
 	return False
 


### PR DESCRIPTION
I faced a situation with a patient appointment doctype when I tried to cancel it and there was a linked sales invoice, case when I want to cancel the patient appointment and the sales invoice is not submitted yet, then the existing cancel function will show an error when trying to cancel an submit invoice