### PR TITLE
fix(ci): failing server tests

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -4,7 +4,7 @@ set -ex
 
 cd ~ || exit
 
-sudo apt-get install redis-server libcups2-dev -qq
+sudo apt-get update && sudo apt-get install redis-server libcups2-dev --fix-missing
 
 pip install frappe-bench
 


### PR DESCRIPTION
install fails on new setup
```
+ sudo apt-get install redis-server libcups2-dev -qq
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/cups/libcupsimage2_2.4.1op1-1ubuntu4.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/cups/libcupsimage2-dev_2.4.1op1-1ubuntu4.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/cups/libcups2-dev_2.4.1op1-1ubuntu4.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```