### PR TITLE
fix: Appointment Cancel - move Cancelled from event_type to status

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -409,7 +409,7 @@ def cancel_appointment(appointment_id):
 
 	if appointment.event:
 		event_doc = frappe.get_doc("Event", appointment.event)
-		event_doc.event_type = "Cancelled"
+		event_doc.status = "Cancelled"
 		event_doc.save()
 
 	frappe.msgprint(msg)


### PR DESCRIPTION
As _Cancelled_ option moved from event_type to status  in Event doctype,  related change done in Healthcare