### PR TITLE
fix: custom fields - Service Unit, Practitioner and Department in Sales Invoice Item

### DIFF
--- a/healthcare/healthcare/custom_doctype/sales_invoice.py
+++ b/healthcare/healthcare/custom_doctype/sales_invoice.py
@@ -40,5 +40,10 @@ class HealthcareSalesInvoice(SalesInvoice):
 				item_line.reference_dn = checked_item["dn"]
 			if checked_item["description"]:
 				item_line.description = checked_item["description"]
+			if checked_item["dt"] == "Lab Test":
+				lab_test = frappe.get_doc("Lab Test", checked_item["dn"])
+				item_line.service_unit = lab_test.service_unit
+				item_line.practitioner = lab_test.practitioner
+				item_line.medical_department = lab_test.department
 
 		self.set_missing_values(for_validate=True)

--- a/healthcare/healthcare/doctype/lab_test/lab_test.json
+++ b/healthcare/healthcare/doctype/lab_test/lab_test.json
@@ -33,6 +33,7 @@
   "email",
   "mobile",
   "c_b",
+  "service_unit",
   "practitioner",
   "practitioner_name",
   "requesting_department",
@@ -579,6 +580,12 @@
    "fieldtype": "Table",
    "label": "Medical Codes",
    "options": "Codification Table"
+  },
+  {
+   "fieldname": "service_unit",
+   "fieldtype": "Link",
+   "label": "Service Unit",
+   "options": "Healthcare Service Unit"
   }
  ],
  "is_submittable": 1,
@@ -588,7 +595,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2023-02-23 18:56:38.766501",
+ "modified": "2023-06-21 00:31:52.282467",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Lab Test",

--- a/healthcare/healthcare/doctype/lab_test/lab_test.py
+++ b/healthcare/healthcare/doctype/lab_test/lab_test.py
@@ -142,7 +142,7 @@ def create_lab_test_from_encounter(encounter):
 				template = get_lab_test_template(item.lab_test_code)
 				if template:
 					lab_test = create_lab_test_doc(
-						item.invoiced, encounter.practitioner, patient, template, encounter.company
+						encounter.practitioner, patient, template, encounter.company, item.invoiced
 					)
 					lab_test.save(ignore_permissions=True)
 					frappe.db.set_value("Lab Prescription", item.name, "lab_test_created", 1)
@@ -170,7 +170,7 @@ def create_lab_test_from_invoice(sales_invoice):
 				template = get_lab_test_template(item.item_code)
 				if template:
 					lab_test = create_lab_test_doc(
-						True, invoice.ref_practitioner, patient, template, invoice.company
+						invoice.ref_practitioner, patient, template, invoice.company, True, item.service_unit
 					)
 					if item.reference_dt == "Lab Prescription":
 						lab_test.prescription = item.reference_dn
@@ -192,7 +192,9 @@ def get_lab_test_template(item):
 	return False
 
 
-def create_lab_test_doc(invoiced, practitioner, patient, template, company):
+def create_lab_test_doc(
+	practitioner, patient, template, company, invoiced=False, service_unit=None
+):
 	lab_test = frappe.new_doc("Lab Test")
 	lab_test.invoiced = invoiced
 	lab_test.practitioner = practitioner
@@ -207,6 +209,7 @@ def create_lab_test_doc(invoiced, practitioner, patient, template, company):
 	lab_test.lab_test_group = template.lab_test_group
 	lab_test.result_date = getdate()
 	lab_test.company = company
+	lab_test.service_unit = service_unit
 	return lab_test
 
 

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -488,6 +488,13 @@ def get_healthcare_service_item(is_inpatient):
 	return service_item
 
 
+def manage_invoice_validate(doc, method):
+	if doc.service_unit and len(doc.items):
+		for item in doc.items:
+			if not item.service_unit:
+				item.service_unit = doc.service_unit
+
+
 def manage_invoice_submit_cancel(doc, method):
 	if not doc.patient:
 		return

--- a/healthcare/hooks.py
+++ b/healthcare/hooks.py
@@ -116,6 +116,7 @@ doc_events = {
 	"Sales Invoice": {
 		"on_submit": "healthcare.healthcare.utils.manage_invoice_submit_cancel",
 		"on_cancel": "healthcare.healthcare.utils.manage_invoice_submit_cancel",
+		"validate": "healthcare.healthcare.utils.manage_invoice_validate",
 	},
 	"Company": {
 		"after_insert": "healthcare.healthcare.utils.create_healthcare_service_unit_tree_root",

--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -2,6 +2,7 @@
 healthcare.patches.v0_0.setup_abdm_custom_fields
 healthcare.patches.v0_0.set_medical_code_from_field_to_codification_table
 healthcare.patches.v15_0.set_fee_validity_status
+healthcare.patches.v15_0.create_custom_fields_in_sales_invoice_item
 
 [post_model_sync]
 healthcare.patches.v15_0.rename_field_medical_department_in_appoitment_type_service_item

--- a/healthcare/patches/v15_0/create_custom_fields_in_sales_invoice_item.py
+++ b/healthcare/patches/v15_0/create_custom_fields_in_sales_invoice_item.py
@@ -1,0 +1,43 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+	custom_field = {
+		"Sales Invoice Item": [
+			{
+				"fieldname": "practitioner",
+				"label": "Practitioner",
+				"fieldtype": "Link",
+				"options": "Healthcare Practitioner",
+				"insert_after": "reference_dn",
+				"read_only": True,
+			},
+			{
+				"fieldname": "medical_department",
+				"label": "Medical Department",
+				"fieldtype": "Link",
+				"options": "Medical Department",
+				"insert_after": "delivered_qty",
+				"read_only": True,
+			},
+			{
+				"fieldname": "service_unit",
+				"label": "Service Unit",
+				"fieldtype": "Link",
+				"options": "Healthcare Service Unit",
+				"insert_after": "medical_department",
+				"read_only": True,
+			},
+		],
+		"Sales Invoice": [
+			{
+				"fieldname": "service_unit",
+				"label": "Service Unit",
+				"fieldtype": "Link",
+				"options": "Healthcare Service Unit",
+				"insert_after": "customer_name",
+			},
+		],
+	}
+
+	create_custom_fields(custom_field)

--- a/healthcare/public/js/sales_invoice.js
+++ b/healthcare/public/js/sales_invoice.js
@@ -32,8 +32,26 @@ frappe.ui.form.on('Sales Invoice', {
 			frm.set_value("customer", "");
 			frm.set_df_property("customer", "read_only", 0);
 		}
+	},
+
+	service_unit: function (frm) {
+		set_service_unit(frm);
+	},
+
+	items_add: function (frm) {
+		set_service_unit(frm);
 	}
 });
+
+var set_service_unit = function (frm) {
+	if (frm.doc.service_unit && frm.doc.items.length > 0) {
+		frm.doc.items.forEach((item) => {
+			if (!item.service_unit) {
+				frappe.model.set_value(item.doctype, item.name, "service_unit", frm.doc.service_unit);
+			}
+		});
+	}
+};
 
 var get_healthcare_services_to_invoice = function(frm) {
 	var me = this;

--- a/healthcare/setup.py
+++ b/healthcare/setup.py
@@ -51,6 +51,13 @@ data = {
 				"options": "Healthcare Practitioner",
 				"insert_after": "customer",
 			},
+			{
+				"fieldname": "service_unit",
+				"label": "Service Unit",
+				"fieldtype": "Link",
+				"options": "Healthcare Service Unit",
+				"insert_after": "customer_name",
+			},
 		],
 		"Sales Invoice Item": [
 			{
@@ -66,6 +73,30 @@ data = {
 				"fieldtype": "Dynamic Link",
 				"options": "reference_dt",
 				"insert_after": "reference_dt",
+			},
+			{
+				"fieldname": "practitioner",
+				"label": "Practitioner",
+				"fieldtype": "Link",
+				"options": "Healthcare Practitioner",
+				"insert_after": "reference_dn",
+				"read_only": True,
+			},
+			{
+				"fieldname": "medical_department",
+				"label": "Medical Department",
+				"fieldtype": "Link",
+				"options": "Medical Department",
+				"insert_after": "delivered_qty",
+				"read_only": True,
+			},
+			{
+				"fieldname": "service_unit",
+				"label": "Service Unit",
+				"fieldtype": "Link",
+				"options": "Healthcare Service Unit",
+				"insert_after": "medical_department",
+				"read_only": True,
 			},
 		],
 		"Stock Entry": [


### PR DESCRIPTION
- Add Custom fields in Sales Invoice Item (Practitioner, Medical Department, Service Unit) and Sales Invoice (Service Unit)
- Set service unit in item table if not set
- Set Service Unit in lab test if lab test item is invoiced
- Patch to add custom field if not existing