### PR TITLE
fix: Remove 'No Lab Tests created' message

### DIFF
--- a/healthcare/healthcare/doctype/lab_test/lab_test.py
+++ b/healthcare/healthcare/doctype/lab_test/lab_test.py
@@ -153,8 +153,6 @@ def create_multiple(doctype, docname):
 		frappe.msgprint(
 			_("Lab Test(s) {0} created successfully").format(lab_test_created), indicator="green"
 		)
-	else:
-		frappe.msgprint(_("No Lab Tests created"))
 
 
 def create_lab_test_from_encounter(encounter):


### PR DESCRIPTION
'No Lab Tests created' message is showing up when we do the invoicing of Items like Patient Encounter(even when Lab test is not part of Encounter), Patient Appointment etc . The message as such is not required, hence removing it.