### PR TITLE
feat: create orders on encounter save

### DIFF
--- a/healthcare/healthcare/doctype/drug_prescription/drug_prescription.json
+++ b/healthcare/healthcare/doctype/drug_prescription/drug_prescription.json
@@ -23,6 +23,7 @@
   "section_break_u9av",
   "intent",
   "priority",
+  "medication_request",
   "section_break_13",
   "comment",
   "update_schedule"
@@ -170,11 +171,19 @@
    "fieldtype": "Link",
    "label": "Priority",
    "options": "FHIR Value Set"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "medication_request",
+   "fieldtype": "Data",
+   "label": "Medication Request",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-10-31 15:44:26.100565",
+ "modified": "2023-11-01 23:09:36.121900",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Drug Prescription",

--- a/healthcare/healthcare/doctype/lab_prescription/lab_prescription.json
+++ b/healthcare/healthcare/doctype/lab_prescription/lab_prescription.json
@@ -10,6 +10,7 @@
   "lab_test_code",
   "lab_test_name",
   "invoiced",
+  "service_request",
   "column_break_4",
   "lab_test_comment",
   "lab_test_created",
@@ -92,11 +93,19 @@
    "fieldtype": "Link",
    "label": "Patient Care Type",
    "options": "Patient Care Type"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "service_request",
+   "fieldtype": "Data",
+   "label": "Service Request",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-10-31 13:01:53.258924",
+ "modified": "2023-11-01 23:08:47.227779",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Lab Prescription",

--- a/healthcare/healthcare/doctype/medication_request/test_medication_request.py
+++ b/healthcare/healthcare/doctype/medication_request/test_medication_request.py
@@ -21,7 +21,7 @@ class TestMedicationRequest(unittest.TestCase):
 	def test_medication_request(self):
 		patient, practitioner = create_healthcare_docs()
 		medication = create_medcation()
-		encounter = create_encounter(patient, practitioner, "drug_prescription", medication)
+		encounter = create_encounter(patient, practitioner, "drug_prescription", medication, submit=True)
 		self.assertTrue(frappe.db.exists("Medication Request", {"order_group": encounter.name}))
 		medication_request = frappe.db.get_value(
 			"Medication Request", {"order_group": encounter.name}, "name"

--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.json
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.json
@@ -29,6 +29,7 @@
   "medical_department",
   "google_meet_link",
   "invoiced",
+  "submit_orders_on_save",
   "sb_symptoms",
   "symptoms",
   "symptoms_in_print",
@@ -346,7 +347,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "\nOpen\nWaiting For Review\nCompleted\nCancelled",
+   "options": "\nOpen\nOrdered\nCompleted\nCancelled",
    "read_only": 1
   },
   {
@@ -354,6 +355,13 @@
    "fieldtype": "Table",
    "label": "Observations",
    "options": "Observation Prescription"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.__islocal;",
+   "fieldname": "submit_orders_on_save",
+   "fieldtype": "Check",
+   "label": "Submit Orders on Save"
   }
  ],
  "is_submittable": 1,
@@ -386,7 +394,20 @@
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": [],
+ "states": [
+  {
+   "color": "Orange",
+   "title": "Ordered"
+  },
+  {
+   "color": "Blue",
+   "title": "Completed"
+  },
+  {
+   "color": "Red",
+   "title": "Cancelled"
+  }
+ ],
  "title_field": "title",
  "track_changes": 1,
  "track_seen": 1

--- a/healthcare/healthcare/doctype/procedure_prescription/procedure_prescription.json
+++ b/healthcare/healthcare/doctype/procedure_prescription/procedure_prescription.json
@@ -10,6 +10,7 @@
   "procedure_name",
   "department",
   "practitioner",
+  "service_request",
   "column_break_ky11",
   "date",
   "comments",
@@ -117,11 +118,19 @@
   {
    "fieldname": "column_break_ky11",
    "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "service_request",
+   "fieldtype": "Data",
+   "label": "Service Request",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-10-31 12:58:54.804015",
+ "modified": "2023-11-01 23:09:04.600093",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Procedure Prescription",

--- a/healthcare/healthcare/doctype/therapy_plan_detail/therapy_plan_detail.json
+++ b/healthcare/healthcare/doctype/therapy_plan_detail/therapy_plan_detail.json
@@ -8,6 +8,7 @@
   "therapy_type",
   "no_of_sessions",
   "sessions_completed",
+  "service_request",
   "section_break_hywn",
   "patient_care_type",
   "column_break_eawy",
@@ -63,11 +64,19 @@
    "fieldtype": "Link",
    "label": "Priority",
    "options": "FHIR Value Set"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "service_request",
+   "fieldtype": "Data",
+   "label": "Service Request",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-10-31 13:42:31.937951",
+ "modified": "2023-11-01 23:10:20.015399",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Therapy Plan Detail",


### PR DESCRIPTION
If 'Submit Orders on Save' field in the encounter is checked, Medication/Service Requests will be created upon saving the encounter instead of upon submission. 
This feature enables the practitioner to prescribe orders without submitting the encounter.

![encounter-submit-orders](https://github.com/frappe/health/assets/48046415/be2ca6a2-bcd8-4627-95e4-8b577d91c75d)

docs - [Documentation]( https://frappehealth.com/docs/v15/user/manual/en/healthcare/servicemedicationrequest )
