### PR TITLE
fix: patches

### DIFF
--- a/healthcare/patches/v15_0/rename_automate_appointment_invoicing.py
+++ b/healthcare/patches/v15_0/rename_automate_appointment_invoicing.py
@@ -6,15 +6,7 @@ def execute():
 	frappe.reload_doc("healthcare", "doctype", frappe.scrub("Healthcare Settings"))
 
 	try:
-		# Rename the field
 		rename_field("Healthcare Settings", "automate_appointment_invoicing", "show_payment_popup")
-
-		# Copy the value
-		old_value = frappe.db.get_single_value("Healthcare Settings", "show_payment_popup")
-		frappe.db.set_single_value(
-			"Healthcare Settings", "show_payment_popup", 1 if old_value == 1 else 0
-		)
-
 	except Exception as e:
 		if e.args and e.args[0]:
 			raise

--- a/healthcare/patches/v15_0/setup_service_request.py
+++ b/healthcare/patches/v15_0/setup_service_request.py
@@ -7,8 +7,6 @@ from healthcare.setup import setup_service_request_masters
 
 def execute():
 	frappe.reload_doc("healthcare", "doctype", "Patient Care Type")
-	frappe.reload_doc("healthcare", "doctype", "Service Request Intent")
-	frappe.reload_doc("healthcare", "doctype", "Service Request Priority")
 
 	setup_service_request_masters()
 


### PR DESCRIPTION
- removed reload statements for deleted doctypes, shows warning during patch run
```
service_request_intent.json missing
service_request_priority.json missing
```
- removed unnecessary set_value after rename