### PR TITLE
fix: Service Request changes

### DIFF
--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -85,6 +85,7 @@ def create_observation(selected, sample_collection, component_observations=None,
 					invoice=sample_col_doc.get("reference_name"),
 					practitioner=sample_col_doc.get("referring_practitioner"),
 					child=obs.get("reference_child") if obs.get("reference_child") else "",
+					service_request=obs.get("service_request"),
 				)
 				if observation:
 					frappe.db.set_value(
@@ -102,8 +103,8 @@ def create_observation(selected, sample_collection, component_observations=None,
 					component_observations = json.loads(obs.get("component_observations"))
 					for j, comp in enumerate(component_observations):
 						observation = add_observation(
-							sample_col_doc.get("patient"),
-							comp.get("observation_template"),
+							patient=sample_col_doc.get("patient"),
+							template=comp.get("observation_template"),
 							doc="Sample Collection",
 							docname=sample_collection,
 							parent=obs.get("component_observation_parent"),
@@ -111,6 +112,7 @@ def create_observation(selected, sample_collection, component_observations=None,
 							invoice=sample_col_doc.get("reference_name"),
 							practitioner=sample_col_doc.get("referring_practitioner"),
 							child=obs.get("reference_child") if obs.get("reference_child") else "",
+							service_request=obs.get("service_request"),
 						)
 						if observation:
 							comp["status"] = "Collected"

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -17,6 +17,9 @@ from healthcare.healthcare.doctype.observation.observation import add_observatio
 from healthcare.healthcare.doctype.observation_template.observation_template import (
 	get_observation_template_details,
 )
+from healthcare.healthcare.doctype.sample_collection.sample_collection import (
+	set_component_observation_data,
+)
 
 
 class ServiceRequest(ServiceRequestController):
@@ -260,7 +263,7 @@ def make_observation(service_request):
 		if len(sample_reqd_component_obs) > 0:
 			save_sample_collection = True
 			obs_template = frappe.get_doc("Observation Template", service_request.template_dn)
-
+			data = set_component_observation_data(service_request.template_dn)
 			# append parent template
 			sample_collection.append(
 				"observation_sample_collection",
@@ -273,6 +276,7 @@ def make_observation(service_request):
 						service_request.template_dn,
 						"container_closure_color",
 					),
+					"component_observations": json.dumps(data),
 					"uom": obs_template.uom,
 					"status": "Open",
 					"sample_qty": obs_template.sample_qty,

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -233,7 +233,12 @@ def make_observation(service_request):
 		return name_ref_in_child[0], name_ref_in_child[1], "New"
 	else:
 		exist_sample_collection = frappe.db.exists(
-			"Sample Collection", {"reference_name": service_request.order_group}
+			"Sample Collection",
+			{
+				"reference_name": service_request.order_group,
+				"docstatus": 0,
+				"patient": service_request.patient,
+			},
 		)
 
 	if template.has_component:


### PR DESCRIPTION
- Issue: When creating a sample collection for a Grouped Observation, we uses the same Sample Collection document initially created against a Service Request from Same Patient Encounter(insert orders without submit), the component data is not being set.
Additionally, need to verify whether the reusing Sample Collection is in Draft mode.
- Pass service request reference from Sample child to Observation (to parent only for grouped observations).
- Check patient also when creating Sample Collection from Service Request.