### PR TITLE
fix: remove translations from hooks.py portal dict

### DIFF
--- a/healthcare/hooks.py
+++ b/healthcare/hooks.py
@@ -252,25 +252,25 @@ domains = {
 # nosemgrep
 standard_portal_menu_items = [
 	{
-		"title": _("Personal Details"),
+		"title": "Personal Details",
 		"route": "/personal-details",
 		"reference_doctype": "Patient",
 		"role": "Patient",
 	},
 	{
-		"title": _("Lab Test"),
+		"title": "Lab Test",
 		"route": "/lab-test",
 		"reference_doctype": "Lab Test",
 		"role": "Patient",
 	},
 	{
-		"title": _("Prescription"),
+		"title": "Prescription",
 		"route": "/prescription",
 		"reference_doctype": "Patient Encounter",
 		"role": "Patient",
 	},
 	{
-		"title": _("Patient Appointment"),
+		"title": "Patient Appointment",
 		"route": "/patient-appointments",
 		"reference_doctype": "Patient Appointment",
 		"role": "Patient",


### PR DESCRIPTION
**Issue:**
whenever instaling health app or using the command "bench version" we get the following error:
<img width="888" alt="Screenshot 2024-01-29 at 10 59 02 PM" src="https://github.com/frappe/health/assets/65544983/e2499511-c432-47df-907e-812fd6f160ae">


**Reason:**
Circular Import