### PR TITLE
fix: event permission issue

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -348,7 +348,7 @@ class PatientAppointment(Document):
 				event_doc.starts_on = starts_on
 				event_doc.ends_on = ends_on
 				event_doc.add_video_conferencing = self.add_video_conferencing
-				event_doc.save()
+				event_doc.save(ignore_permissions=True)
 				event_doc.reload()
 				self.google_meet_link = event_doc.google_meet_link
 


### PR DESCRIPTION
If a user tries to change the patient appointment schedule that is done by another user,  it throws a permission error. This error happens because or event doctype has different permission structure.

 I have added event_doc.save(ignore_permissions=True)  to fix this.


Error details
-----------
"apps/healthcare/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py", line 46, in validate
    self.update_event()
  File "apps/healthcare/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py", line 350, in update_event
    event_doc.save()
  File "apps/frappe/frappe/model/document.py", line 309, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 333, in _save
    self.check_permission("write", "save")
  File "apps/frappe/frappe/model/document.py", line 196, in check_permission
    self.raise_no_permission_to(permtype)
  File "apps/frappe/frappe/model/document.py", line 218, in raise_no_permission_to
    raise frappe.PermissionError
frappe.exceptions.PermissionError