### PR TITLE
build(deps): bump python-barcode to "0.15.1"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
   "responses==0.23.1",
-  "python-barcode~=0.13.1",
+  "python-barcode~=0.15.1",
 ]
 
 [build-system]


### PR DESCRIPTION
Updated the version of the shared dependency to ensure compatibility with other apps based on frappe.