### PR TITLE
fix: make medication optional for drug prescription and Medication Request

### DIFF
--- a/healthcare/healthcare/doctype/medication/medication.py
+++ b/healthcare/healthcare/doctype/medication/medication.py
@@ -20,6 +20,21 @@ class Medication(Document):
 		if self.linked_items:
 			self.update_item_and_item_price()
 
+	def validate(self):
+		if self.linked_items:
+			for item in self.linked_items:
+				exist_medication = frappe.db.get_value(
+					"Medication Linked Item",
+					{"item": item.item_code, "parent": ("!=", self.name)},
+					"parent",
+				)
+				if exist_medication:
+					frappe.throw(
+						_(
+							"Item <b>{}</b> has been already used in <b><a href='/app/medication/{}'>Medication</a></b>"
+						).format(item.item_code, exist_medication)
+					)
+
 	def update_item_and_item_price(self):
 		for item in self.linked_items:
 			if not item.item:

--- a/healthcare/healthcare/doctype/medication_request/medication_request.json
+++ b/healthcare/healthcare/doctype/medication_request/medication_request.json
@@ -11,7 +11,7 @@
   "title",
   "naming_series",
   "medication",
-  "medicaiton_item",
+  "medication_item",
   "order_date",
   "expected_date",
   "order_time",
@@ -414,7 +414,6 @@
    "fieldtype": "Link",
    "label": "Medication",
    "options": "Medication",
-   "reqd": 1,
    "search_index": 1
   },
   {
@@ -448,22 +447,23 @@
    "read_only": 1
   },
   {
-   "fieldname": "medicaiton_item",
-   "fieldtype": "Link",
-   "label": "Medicaiton Item",
-   "options": "Item"
-  },
-  {
    "fetch_from": "practitioner.user_id",
    "fieldname": "practitioner_email",
    "fieldtype": "Data",
    "label": "Practitioner Email"
+  },
+  {
+   "fieldname": "medication_item",
+   "fieldtype": "Link",
+   "label": "Medication Item",
+   "options": "Item",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-01-09 14:01:37.695631",
+ "modified": "2024-02-13 12:58:48.827434",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Medication Request",

--- a/healthcare/healthcare/doctype/medication_request/test_medication_request.py
+++ b/healthcare/healthcare/doctype/medication_request/test_medication_request.py
@@ -5,6 +5,8 @@ import unittest
 
 import frappe
 
+from erpnext.stock.doctype.item.test_item import create_item
+
 from healthcare.healthcare.doctype.patient_appointment.test_patient_appointment import (
 	create_healthcare_docs,
 )
@@ -20,7 +22,7 @@ class TestMedicationRequest(unittest.TestCase):
 
 	def test_medication_request(self):
 		patient, practitioner = create_healthcare_docs()
-		medication = create_medcation()
+		medication = create_medication()
 		encounter = create_encounter(patient, practitioner, "drug_prescription", medication, submit=True)
 		self.assertTrue(frappe.db.exists("Medication Request", {"order_group": encounter.name}))
 		medication_request = frappe.db.get_value(
@@ -39,7 +41,7 @@ class TestMedicationRequest(unittest.TestCase):
 			)
 
 
-def create_medcation():
+def create_medication():
 	if not frappe.db.exists("Medication", "_Test Medication"):
 		if not frappe.db.exists("Medication Class", "Tablet"):
 			try:
@@ -52,6 +54,8 @@ def create_medcation():
 			except frappe.DuplicateEntryError:
 				pass
 		try:
+			item_name = "_Test PL Item"
+			item = create_item(item_code=item_name, is_stock_item=0)
 			medication = frappe.get_doc(
 				{
 					"doctype": "Medication",
@@ -60,13 +64,12 @@ def create_medcation():
 					"abbr": "Test",
 					"strength": 500,
 					"strength_uom": "Unit",
-					"item_code": "_Test",
-					"item_group": "Drug",
 					"dosage_form": "Capsule",
 					"default_prescription_dosage": "0-1-0",
 					"default_prescription_duration": "1 Hour",
 					"is_billable": 1,
 					"rate": 800,
+					"linked_items": [{"item": item.item_code, "item_code": item.item_name, "item_group": "Drug"}],
 				}
 			).insert(ignore_permissions=True, ignore_mandatory=True)
 			return medication

--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -181,10 +181,18 @@ frappe.ui.form.on('Patient Encounter', {
 		if (frappe.meta.get_docfield('Drug Prescription', 'medication').in_list_view === 1) {
 			frm.set_query('drug_code', 'drug_prescription', function(doc, cdt, cdn) {
 				let row = frappe.get_doc(cdt, cdn);
-				return {
-					query: 'healthcare.healthcare.doctype.patient_encounter.patient_encounter.get_medications_query',
-					filters: { name: row.medication }
-				};
+				if (row.medication) {
+					return {
+						query: 'healthcare.healthcare.doctype.patient_encounter.patient_encounter.get_medications_query',
+						filters: { name: row.medication }
+					};
+				} else {
+					return {
+						filters: {
+							is_stock_item: 1
+						}
+					};
+				}
 			});
 		}
 		var table_list =  ["drug_prescription", "lab_test_prescription", "procedure_prescription", "therapies"]

--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.py
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.py
@@ -141,10 +141,17 @@ class PatientEncounter(Document):
 			return
 
 		for item in self.drug_prescription:
-			if not item.medication and not item.drug_code:
-				frappe.throw(
-					_("Row #{0} (Drug Prescription): Medication or Item Code is mandatory").format(item.idx)
-				)
+			if not item.drug_code:
+				frappe.throw(_("Row #{0} (Drug Prescription): Drug Code is mandatory").format(item.idx))
+			else:
+				if not item.medication:
+					medication = frappe.db.get_value(
+						"Medication Linked Item",
+						{"item": item.drug_code},
+						"parent",
+					)
+					if medication:
+						item.medication = medication
 
 	def validate_therapies(self):
 		if not self.therapies:

--- a/healthcare/healthcare/doctype/service_request/test_service_request.py
+++ b/healthcare/healthcare/doctype/service_request/test_service_request.py
@@ -130,7 +130,9 @@ def create_encounter(
 				type, {"lab_test_code": template.item, "lab_test_name": template.lab_test_name}
 			)
 		elif type == "drug_prescription":
-			patient_encounter.append(type, {"medication": template.name})
+			patient_encounter.append(
+				type, {"medication": template.name, "drug_code": template.linked_items[0].get("item")}
+			)
 	else:
 		patient_encounter.append(type, {"observation_template": template.name})
 

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -684,15 +684,20 @@ def get_drugs_to_invoice(encounter):
 					},
 				)
 				for medication_request in medication_requests:
-					is_billable = frappe.get_cached_value(
-						"Medication", medication_request.medication, ["is_billable"]
-					)
+					if medication_request.medication:
+						is_billable = frappe.get_cached_value(
+							"Medication", medication_request.medication, ["is_billable"]
+						)
+					else:
+						is_billable = frappe.db.exists(
+							"Item", {"name": medication_request.medication_item, "disabled": False}
+						)
 
 					description = ""
 					if medication_request.dosage and medication_request.period:
 						description = _("{0} for {1}").format(medication_request.dosage, medication_request.period)
 
-					if medication_request.medicaiton_item and is_billable:
+					if medication_request.medication_item and is_billable:
 						billable_order_qty = medication_request.get("quantity", 1) - medication_request.get(
 							"qty_invoiced", 0
 						)
@@ -711,7 +716,7 @@ def get_drugs_to_invoice(encounter):
 							{
 								"reference_type": "Medication Request",
 								"reference_name": medication_request.name,
-								"drug_code": medication_request.medicaiton_item,
+								"drug_code": medication_request.medication_item,
 								"quantity": billable_order_qty,
 								"description": description,
 							}


### PR DESCRIPTION
- Make medication optional for drug prescription (in Patient encounter) and Medication Request
- Validate Item in Medication Item table (item must be unique for Medication)
- In Patient Encounter set medication in Drug Prescription table of Medication exists and only Drug Item is selected