### PR TITLE
fix(Patient Appointment): event permission issue

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -349,6 +349,7 @@ class PatientAppointment(Document):
 				event_doc.ends_on = ends_on
 				event_doc.add_video_conferencing = self.add_video_conferencing
 				event_doc.save()
+				event_doc.save(ignore_permissions=True)
 				event_doc.reload()
 				self.google_meet_link = event_doc.google_meet_link
 


### PR DESCRIPTION
If a user attempts to change the schedule of a patient appointment that was created by another user, a permission error is thrown. This error occurs because event doctype has a different permission structure.