### PR TITLE
fix(Vital Signs): remove no_copy from appointment field

### DIFF
--- a/healthcare/healthcare/doctype/vital_signs/vital_signs.json
+++ b/healthcare/healthcare/doctype/vital_signs/vital_signs.json
@@ -71,7 +71,6 @@
    "fieldtype": "Link",
    "in_filter": 1,
    "label": "Patient Appointment",
-   "no_copy": 1,
    "options": "Patient Appointment",
    "print_hide": 1,
    "read_only": 1
@@ -257,7 +256,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-01-14 19:10:30.668831",
+ "modified": "2024-03-07 12:14:26.166928",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Vital Signs",


### PR DESCRIPTION
Issue:-
 appointment reference does not carry forward to Vital Signs when created from a Patient Appointment.