### PR TITLE
fix(Diagnostic Report): remove doc from is_new()

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.js
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.js
@@ -11,7 +11,7 @@ frappe.ui.form.on("Diagnostic Report", {
 		}
 	},
 	before_save: function(frm) {
-		if (!frm.doc.is_new() && frm.is_dirty()) {
+		if (!frm.is_new() && frm.is_dirty()) {
 			this.diagnostic_report.save_action("save")
 		}
 	},


### PR DESCRIPTION
Issue: "Can't save Diagnostic Report"

fix: remove 'doc' from is_new() 