### PR TITLE
fix(patient): error in age calculation

### DIFF
--- a/healthcare/healthcare/doctype/patient/patient.js
+++ b/healthcare/healthcare/doctype/patient/patient.js
@@ -104,11 +104,10 @@ let create_medical_record = function (frm) {
 };
 
 let get_age = function (birth) {
-	let ageMS = Date.parse(Date()) - Date.parse(birth);
-	let age = new Date();
-	age.setTime(ageMS);
-	let years = age.getFullYear() - 1970;
-	return `${years} ${__('Year(s)')} ${age.getMonth()} ${__('Month(s)')} ${age.getDate()} ${__('Day(s)')}`
+	let birth_moment = moment(birth);
+	let current_moment = moment(Date());
+	let diff = moment.duration(current_moment.diff(birth_moment));
+	return `${diff.years()} ${__('Year(s)')} ${diff.months()} ${__('Month(s)')} ${diff.days()} ${__('Day(s)')}`
 };
 
 let create_vital_signs = function (frm) {


### PR DESCRIPTION
The age of a patient was being bad calculated: between April 1st of different years, will be only years of difference, however, it is not working like that.

![Captura desde 2024-04-01 17-36-35](https://github.com/frappe/health/assets/165695592/9a61d86a-5575-41f0-8ac7-b93be52e41d1)
See that from April 1st of 2019 to now, April 1st of 2024 there are just 5 years of difference. 

Now, using moment library, that is already installed, the age is being well calculated.

![Captura desde 2024-04-01 17-37-17](https://github.com/frappe/health/assets/165695592/389ad3fc-f334-497b-9619-379e551b5bd6)
