### PR TITLE
fix(Nursing Task): unknown column duration error in Healthcare Activity

### DIFF
--- a/healthcare/healthcare/doctype/nursing_task/nursing_task.py
+++ b/healthcare/healthcare/doctype/nursing_task/nursing_task.py
@@ -62,7 +62,9 @@ class NursingTask(Document):
 
 		if not self.requested_end_time:
 			if not self.duration:
-				self.duration = frappe.db.get_value("Healthcare Activity", self.activity, "duration")
+				self.duration = (
+					frappe.db.get_value("Healthcare Activity", self.activity, "activity_duration") or 0
+				)
 			self.requested_end_time = add_to_date(self.requested_start_time, seconds=self.duration)
 
 		# set date based on requested_start_time


### PR DESCRIPTION
- Issue:-
  When inserting Nursing Task with healthcare activity throws unknown column error

![Screenshot from 2024-05-08 09-59-55](https://github.com/Sajinsr/health/assets/89388830/68463d04-3cee-4f54-be0c-04b46be32486)
