### PR TITLE
fix(Medication Request): Update default value for status field

### DIFF
--- a/healthcare/healthcare/doctype/medication_request/medication_request.json
+++ b/healthcare/healthcare/doctype/medication_request/medication_request.json
@@ -121,7 +121,7 @@
   },
   {
    "allow_on_submit": 1,
-   "default": "Draft",
+   "default": "draft-Medication Request Status",
    "depends_on": "eval:!doc.__islocal",
    "fieldname": "status",
    "fieldtype": "Link",
@@ -463,7 +463,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-02-13 12:58:48.827434",
+ "modified": "2024-05-08 10:12:52.606084",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Medication Request",

--- a/healthcare/healthcare/doctype/medication_request/medication_request.py
+++ b/healthcare/healthcare/doctype/medication_request/medication_request.py
@@ -20,7 +20,6 @@ class MedicationRequest(ServiceRequestController):
 
 	def before_insert(self):
 		self.calculate_total_dispensable_quantity()
-		self.status = "draft-Medication Request Status"
 
 		if self.amended_from:
 			frappe.db.set_value(


### PR DESCRIPTION
When trying to create a new Medication Request, providing all the necessary main data, this error is displayed. The status 'Draft' is not found because the actual value found in the database is 'draft-Medication Request Status':

![Screenshot from 2024-05-08 10-35-41](https://github.com/frappe/health/assets/169169293/25d0cb46-7bb2-43ea-b569-7101a6bbca1b)


