### PR TITLE
fix(Observation): local variable reference error in Diagnostic Report

### DIFF
--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -108,6 +108,7 @@ def get_observation_details(docname):
 	reference = frappe.get_value(
 		"Diagnostic Report", docname, ["docname", "ref_doctype"], as_dict=True
 	)
+	observation = []
 
 	if reference.get("ref_doctype") == "Sales Invoice":
 		observation = frappe.get_list(


### PR DESCRIPTION
Issue:
 Local variable reference error showing in Diagnostic Report.

![Screenshot from 2024-06-06 23-15-57](https://github.com/frappe/health/assets/89388830/9fe1683d-264f-4311-9a76-4f8c4b5406eb)

