### PR TITLE
fix(Patient Appointment): remove redundant save command

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -348,7 +348,6 @@ class PatientAppointment(Document):
 				event_doc.starts_on = starts_on
 				event_doc.ends_on = ends_on
 				event_doc.add_video_conferencing = self.add_video_conferencing
-				event_doc.save()
 				event_doc.save(ignore_permissions=True)
 				event_doc.reload()
 				self.google_meet_link = event_doc.google_meet_link


### PR DESCRIPTION
Issue:-
When rescheduling patient appointment using a user login getting permission error:
![patient_error](https://github.com/user-attachments/assets/160e8f98-a6ef-458b-9822-2ce72d117f39)

