### PR TITLE
fix(Patient Appointment): rearrange method get_appointment_billing_item_and_rate

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -455,14 +455,14 @@ def get_appointment_billing_item_and_rate(doc):
 
 	is_inpatient = doc.inpatient_record
 
-	if doc.get("practitioner"):
-		service_item, practitioner_charge = get_practitioner_billing_details(
-			doc.practitioner, is_inpatient
+	if doc.get("appointment_type"):
+		service_item, practitioner_charge = get_appointment_type_billing_details(
+			doc.appointment_type, department if department else service_unit, is_inpatient
 		)
 
-	if not service_item and doc.get("appointment_type"):
-		service_item, appointment_charge = get_appointment_type_billing_details(
-			doc.appointment_type, department if department else service_unit, is_inpatient
+	if not service_item and doc.get("practitioner"):
+		service_item, appointment_charge = get_practitioner_billing_details(
+			doc.practitioner, is_inpatient
 		)
 		if not practitioner_charge:
 			practitioner_charge = appointment_charge


### PR DESCRIPTION
Issue #296 

According to documentation the charges set on the appointment type should override the charges set at practitioner level.

Docs Link:
https://frappehealth.com/patient-appointment#:~:text=If%20the%20Appointment,the%20above%20configuration.

However, the system was still applying the practitioner charges while expected behaviour is to apply appointment type charges.
<img width="805" alt="278662539-c3831eb9-88c6-4843-8ba4-37a6895ac5d6" src="https://github.com/user-attachments/assets/8576af1d-a02b-4f91-a288-5a648c50975d">

<img width="955" alt="278660000-ea4e0c53-7c37-489e-bb79-1b99cb8ccd92" src="https://github.com/user-attachments/assets/773c77d1-58a0-4a8d-ae7e-6880cac3e0e1">
