### PR TITLE
fix: nursing tasks and related tests

### DIFF
--- a/healthcare/healthcare/doctype/nursing_task/nursing_task.py
+++ b/healthcare/healthcare/doctype/nursing_task/nursing_task.py
@@ -14,16 +14,12 @@ from erpnext import get_default_company
 
 class NursingTask(Document):
 	def before_insert(self):
-		# set requested start / end
 		self.set_task_schedule()
-
 		self.title = "{} - {}".format(_(self.patient), _(self.activity))
-
 		self.age = frappe.get_doc("Patient", self.patient).get_age()
 
 	def validate(self):
 		if self.status == "Requested":
-			# auto submit if status is Requested
 			self.docstatus = 1
 
 	def on_submit(self):
@@ -47,10 +43,11 @@ class NursingTask(Document):
 				self.db_set("task_start_time", now_datetime())
 
 		elif self.status == "Completed":
+			task_end_time = now_datetime()
 			self.db_set(
 				{
-					"task_end_time": now_datetime(),
-					"task_duration": time_diff_in_seconds(self.task_end_time, self.task_start_time),
+					"task_end_time": task_end_time,
+					"task_duration": time_diff_in_seconds(task_end_time, self.task_start_time),
 				}
 			)
 

--- a/healthcare/healthcare/doctype/nursing_task/test_nursing_task.py
+++ b/healthcare/healthcare/doctype/nursing_task/test_nursing_task.py
@@ -79,7 +79,8 @@ class TestNursingTask(IntegrationTestCase):
 		complete_nusing_tasks(procedure)
 		procedure.start_procedure()
 
-	def test_admit_inpatient_should_validate_pending_nursing_tasks(self):
+	def test_admit_discharge_inpatient_should_validate_pending_nursing_tasks(self):
+		"""nursing tasks on admit and discharge of same ip_record"""
 		self.settings.allow_discharge_despite_unbilled_services = 1
 		self.settings.save()
 


### PR DESCRIPTION
- initialise task_end_time before calculating task_duration

test -
- tests to start nursing tasks before completing 
- function to start nursing tasks related to a document
- rename inpatient test method