### PR TITLE
fix: medical department field should have mandatory property enabled

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_practitioner/healthcare_practitioner.json
+++ b/healthcare/healthcare/doctype/healthcare_practitioner/healthcare_practitioner.json
@@ -113,7 +113,8 @@
    "ignore_user_permissions": 1,
    "in_standard_filter": 1,
    "label": "Medical Department",
-   "options": "Medical Department"
+   "options": "Medical Department",
+   "reqd" : 1
   },
   {
    "fieldname": "column_break_7",

--- a/healthcare/healthcare/doctype/lab_test/test_lab_test.py
+++ b/healthcare/healthcare/doctype/lab_test/test_lab_test.py
@@ -229,6 +229,7 @@ def create_practitioner():
 		practitioner = frappe.new_doc("Healthcare Practitioner")
 		practitioner.first_name = "_Test Healthcare Practitioner"
 		practitioner.gender = "Female"
+		practitioner.department = "Dermatology"
 		practitioner.op_consulting_charge = 500
 		practitioner.inpatient_visit_charge = 500
 		practitioner.save(ignore_permissions=True)

--- a/healthcare/healthcare/doctype/patient_encounter/test_patient_encounter.py
+++ b/healthcare/healthcare/doctype/patient_encounter/test_patient_encounter.py
@@ -37,6 +37,7 @@ class TestPatientEncounter(IntegrationTestCase):
 				"doctype": "Healthcare Practitioner",
 				"first_name": "Doc",
 				"sex": "MALE",
+				"department": "Dermatology" 
 			}
 		).insert()
 		try:

--- a/healthcare/healthcare/doctype/patient_encounter/test_patient_encounter.py
+++ b/healthcare/healthcare/doctype/patient_encounter/test_patient_encounter.py
@@ -37,7 +37,7 @@ class TestPatientEncounter(IntegrationTestCase):
 				"doctype": "Healthcare Practitioner",
 				"first_name": "Doc",
 				"sex": "MALE",
-				"department": "Dermatology" 
+				"department": "Dermatology",
 			}
 		).insert()
 		try:


### PR DESCRIPTION
- when user click on `Check Availability` button, system not allow to select correct healthcare practitioner if Medical department is not selected. therefore can not check the available slot
- Normally user forget to update Department in Healthcare Practitioner document
- Medical Department should be a mandatory field

<img width="1436" alt="Screenshot 2025-01-02 at 11 31 02 AM" src="https://github.com/user-attachments/assets/3c3a98fc-d238-468d-89cf-db4dd13af6b6" />