### PR TITLE
fix(ci): use the latest mariadb-client version

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -6,7 +6,7 @@ cd ~ || exit
 
 sudo apt update
 sudo apt remove mysql-server mysql-client
-sudo apt install libcups2-dev redis-server mariadb-client-10.6
+sudo apt install libcups2-dev redis-server mariadb-client
 
 pip install frappe-bench
 


### PR DESCRIPTION
fix failing ci on "Package 'mariadb-client-10.6' has no installation candidate"