### PR TITLE
fix: Remove invalid license key from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ authors = [
     { name = "earthians Health Informatics Pvt. Ltd.", email = "info@earthianslive.com" },
 ]
 readme = "README.md"
-license = {file = "LICENSE.txt"}
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
There is additional validation on `license` key as of new release  of flit causing install to fail.

ref: https://flit.pypa.io/en/stable/history.html#version-3-11