### PR TITLE
feat: Patient Referral Management

### DIFF
--- a/healthcare/healthcare/doctype/appointment_type/appointment_type.json
+++ b/healthcare/healthcare/doctype/appointment_type/appointment_type.json
@@ -15,7 +15,9 @@
   "color",
   "billing_tab",
   "price_list",
-  "items"
+  "items",
+  "medical_codes_tab",
+  "codification_table"
  ],
  "fields": [
   {
@@ -75,10 +77,22 @@
    "label": "Allow Booking For",
    "options": "Practitioner\nDepartment\nService Unit",
    "reqd": 1
+  },
+  {
+   "fieldname": "medical_codes_tab",
+   "fieldtype": "Tab Break",
+   "label": "Medical Codes"
+  },
+  {
+   "fieldname": "codification_table",
+   "fieldtype": "Table",
+   "label": "Medical Code",
+   "options": "Codification Table"
   }
  ],
+ "grid_page_length": 50,
  "links": [],
- "modified": "2023-06-10 13:43:27.137414",
+ "modified": "2025-03-31 17:31:51.709349",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Appointment Type",
@@ -112,6 +126,7 @@
  ],
  "quick_entry": 1,
  "restrict_to_domain": "Healthcare",
+ "row_format": "Dynamic",
  "search_fields": "appointment_type",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -28,6 +28,8 @@
   "patient_age",
   "section_break_12",
   "duration",
+  "reference_doctype",
+  "reference_docname",
   "service_request",
   "procedure_template",
   "get_procedure_from_encounter",
@@ -106,9 +108,9 @@
    "in_filter": 1,
    "in_list_view": 1,
    "label": "Status",
+   "no_copy": 1,
    "options": "\nScheduled\nOpen\nConfirmed\nChecked In\nChecked Out\nClosed\nCancelled\nNo Show",
    "read_only": 1,
-   "no_copy": 1,
    "search_index": 1
   },
   {
@@ -423,10 +425,25 @@
    "options": "Service Request",
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "label": "Reference Doctype",
+   "options": "DocType",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reference_docname",
+   "fieldtype": "Dynamic Link",
+   "label": "Reference Docname",
+   "options": "reference_doctype",
+   "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "links": [],
- "modified": "2024-11-20 08:21:29.729408",
+ "modified": "2025-04-01 12:45:08.615248",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Patient Appointment",
@@ -471,6 +488,7 @@
   }
  ],
  "restrict_to_domain": "Healthcare",
+ "row_format": "Dynamic",
  "search_fields": "patient, practitioner, department, appointment_date, appointment_time",
  "show_name_in_global_search": 1,
  "sort_field": "modified",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -60,6 +60,11 @@ class PatientAppointment(Document):
 		send_confirmation_msg(self)
 		self.insert_calendar_event()
 
+		if self.service_request:
+			frappe.db.set_value(
+				"Service Request", self.service_request, "status", "completed-Request Status"
+			)
+
 	def set_title(self):
 		if self.practitioner:
 			self.title = _("{0} with {1}").format(
@@ -508,6 +513,11 @@ def get_appointment_item(appointment_doc, item):
 
 def cancel_appointment(appointment_id):
 	appointment = frappe.get_doc("Patient Appointment", appointment_id)
+	if appointment.service_request:
+		frappe.db.set_value(
+			"Service Request", appointment.service_request, "status", "active-Request Status"
+		)
+
 	if appointment.invoiced:
 		sales_invoice = check_sales_invoice_exists(appointment)
 		if sales_invoice and cancel_sales_invoice(sales_invoice):

--- a/healthcare/healthcare/doctype/service_request/service_request.js
+++ b/healthcare/healthcare/doctype/service_request/service_request.js
@@ -111,6 +111,26 @@ frappe.ui.form.on('Service Request', {
 				frm.trigger('make_observation');
 			}, __('Create'));
 
+		} else if (frm.doc.template_dt === "Appointment Type") {
+			frm.add_custom_button(__("Appointment"), function () {
+				frappe.db.get_value("Patient Appointment", { service_request: frm.doc.name, status: ["!=", "Cancelled"] }, "name")
+					.then(r => {
+						if (Object.keys(r.message).length == 0) {
+							frappe.model.open_mapped_doc({
+								method: "healthcare.healthcare.doctype.service_request.service_request.make_appointment",
+								frm: frm,
+							});
+						} else {
+							if (r.message && r.message.name) {
+								frappe.set_route("Form", "Patient Appointment", r.message.name);
+								frappe.show_alert({
+									message: __("Patient Appointment is already created"),
+									indicator: "info",
+								});
+							}
+						}
+					})
+			}, __("Create"));
 		}
 
 		frm.page.set_inner_btn_group_as_primary(__('Create'));

--- a/healthcare/healthcare/doctype/service_request/test_service_request.py
+++ b/healthcare/healthcare/doctype/service_request/test_service_request.py
@@ -25,8 +25,14 @@ from healthcare.healthcare.doctype.observation_template.test_observation_templat
 	create_observation_template,
 )
 from healthcare.healthcare.doctype.patient_appointment.test_patient_appointment import (
+	create_appointment_type,
 	create_clinical_procedure_template,
 	create_healthcare_docs,
+	create_patient,
+	create_practitioner,
+)
+from healthcare.healthcare.doctype.patient_encounter.patient_encounter import (
+	create_patient_referral,
 )
 from healthcare.healthcare.doctype.service_request.service_request import make_clinical_procedure
 from healthcare.healthcare.doctype.therapy_plan.test_therapy_plan import (
@@ -127,6 +133,42 @@ class TestServiceRequest(unittest.TestCase):
 			observation = create_observation(patient, service_request, obs_template.name)
 			create_sales_invoice(patient, service_request_doc, obs_template, "observation")
 			self.assertEqual(frappe.db.get_value("Observation", observation.name, "invoiced"), 1)
+
+	def test_patient_referral(self):
+		patient = create_patient()
+		practitioner_1 = create_practitioner(id=1)
+		practitioner_2 = create_practitioner(id=2)
+		obs_template = create_observation_template("Total Cholesterol")
+		encounter = create_encounter(
+			patient, practitioner_1, "lab_test_prescription", obs_template, submit=True, obs=True
+		)
+
+		appointment_type = create_appointment_type()
+		refer_to_practitioner(encounter, practitioner_2, appointment_type.name)
+
+		self.assertTrue(
+			frappe.db.exists(
+				"Service Request",
+				{
+					"order_group": encounter.name,
+					"template_dt": "Appointment Type",
+					"template_dn": appointment_type.name,
+				},
+			)
+		)
+
+		self.assertEqual(
+			frappe.db.get_value(
+				"Service Request",
+				{
+					"order_group": encounter.name,
+					"template_dt": "Appointment Type",
+					"template_dn": appointment_type.name,
+				},
+				"referred_to_practitioner",
+			),
+			practitioner_2,
+		)
 
 
 def create_encounter(
@@ -282,3 +324,21 @@ def make_therapy_session(service_request):
 	therapy_session.save()
 
 	return therapy_session
+
+
+def refer_to_practitioner(encounter, practitioner=None, appointment_type=None):
+	if not practitioner:
+		return
+
+	if not appointment_type:
+		return
+
+	references = [
+		{
+			"refer_to": practitioner,
+			"appointment_type": appointment_type,
+			"referral_note": f"Patient {encounter.patient} referred to practitioner {practitioner}",
+		}
+	]
+
+	create_patient_referral(encounter.name, references)


### PR DESCRIPTION
## Patient Referral Management
This feature introduces a streamlined referral process within the Patient Encounter Doctype, enabling efficient patient referrals and improving care coordination.

#### Key Enhancements
1. Referral Action in Patient Encounter
    - [x] Added a "Refer Patient" button in the Patient Encounter form.
    - [x] Allows selecting multiple Practitioners and specifying the Appointment Type for the referral.
    - [x] Optionally, users can provide additional instructions for the receiving provider.

2. Automatic Creation of Service Request
    - [x] When a referral is submitted, a Service Request is automatically created for the selected Appointment Type and Practitioner.
    - [ ] A Patient Appointment should also be generated in a "Referred" status. (Will be added in next PR)

3. Linking & Tracking Referrals
    - [x] The source Patient Encounter is linked to both the Service Request and the Patient Appointment.
    - [x] The Service Request status updates automatically upon appointment creation and cancellation.

This enhancement improves patient management by facilitating seamless referrals and ensuring better tracking of referred encounters.

docs - [Documentation](https://marley.frappe.cloud/wiki/docs/patient_encounter#4-patient-referral-system)

![patient-referral](https://github.com/user-attachments/assets/99c5dfb3-7631-4f75-b162-5db022a5a828)

closes #586 