### PR TITLE
fix: Therapy Session naming

### DIFF
--- a/healthcare/healthcare/doctype/therapy_session/therapy_session.json
+++ b/healthcare/healthcare/doctype/therapy_session/therapy_session.json
@@ -44,7 +44,7 @@
    "fieldname": "naming_series",
    "fieldtype": "Select",
    "label": "Series",
-   "options": "HLC-THP-.YYYY.-"
+   "options": "HLC-THS-.YYYY.-"
   },
   {
    "fieldname": "appointment",
@@ -237,7 +237,8 @@
    "no_copy": 1,
    "options": "Service Request",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "collapsible": 1,
@@ -253,7 +254,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2023-04-06 04:11:55.237021",
+ "modified": "2025-04-06 19:15:28.739455",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Therapy Session",
@@ -287,6 +288,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "patient,appointment,therapy_plan,therapy_type",
  "sort_field": "modified",
  "sort_order": "DESC",


### PR DESCRIPTION
While testing the Develop branch I inspected the Therapy Session database table and there I could see both the
Therapy Session naming and the Therapy Plan naming and I noticed that they are both defined as HLC-THP.  Surely this 
cannot be right.

THP seems best suited to Therapy Plan so I kept that the same.
For Therapy Session, THS seems fitting.

Closes: #639