### PR TITLE
fix: services and medications cannot be on one invoice

### DIFF
--- a/healthcare/public/js/sales_invoice.js
+++ b/healthcare/public/js/sales_invoice.js
@@ -40,6 +40,13 @@ frappe.ui.form.on('Sales Invoice', {
 		}
 	},
 
+	onload_post_render(frm) {
+		if (frm.doc.items && frm.doc.items.length === 1 && !frm.doc.items[0].item_code) {
+			frm.clear_table('items');
+			frm.refresh_field('items');  // Ensure UI updates
+		}
+	},
+
 	patient(frm) {
 		if (frm.doc.patient) {
 			frappe.db.get_value("Patient", frm.doc.patient, "customer")
@@ -186,7 +193,7 @@ var make_list_row= function(columns, invoice_healthcare_services, result={}) {
 var set_primary_action= function(frm, dialog, $results, invoice_healthcare_services) {
 	var me = this;
 	dialog.set_primary_action(__('Add'), function() {
-		frm.clear_table('items');
+//		frm.clear_table('items');
 		let checked_values = get_checked_values($results);
 		if(checked_values.length > 0){
 			if(invoice_healthcare_services) {


### PR DESCRIPTION
Currently it is not possible to put Services as well as Medications on one invoice. This is because when ever items are loaded onto an invoice, there is a frm.clear_table instruction in the function set_primary_action in the file  ..../public/js/sales_invoice.js.

I propose to move this clear_table to an onload_post_render trigger. This will allow for the items-table to be cleared when a new invoice is created but allows for services as well as medications to be added to the invoice without clearing the table first.

By doing it this way, the user has the choice of putting everything onto one invoice or to use more than one invoice.

closes #583