### PR TITLE
feat: Make user-prompt for services and prescriptions wider. Closes #645

### DIFF
--- a/healthcare/public/js/sales_invoice.js
+++ b/healthcare/public/js/sales_invoice.js
@@ -94,6 +94,7 @@ var get_healthcare_services_to_invoice = function(frm, link_customer) {
 	let selected_patient = '';
 	var dialog = new frappe.ui.Dialog({
 		title: __("Get Items from Healthcare Services"),
+		size: 'large',
 		fields:[
 			{
 				fieldtype: 'Link',
@@ -254,6 +255,7 @@ var get_drugs_to_invoice = function(frm, link_customer) {
 	let selected_encounter = '';
 	var dialog = new frappe.ui.Dialog({
 		title: __("Get Items from Medication Requests"),
+		size: 'large',
 		fields:[
 			{ fieldtype: 'Link', options: 'Patient', label: 'Patient', fieldname: "patient", reqd: true },
 			{ fieldtype: 'Link', options: 'Patient Encounter', label: 'Patient Encounter', fieldname: "encounter", reqd: true,


### PR DESCRIPTION
When creating a sales invoice for a patient and using the "Get Items From" > "Health Services" and also the "Get Items From" > "Prescriptions" , then the user-prompt is not wide enough to display all the text of the options to the user.

This PR proposes to make it wider, making it easier for the user to decide which services or prescriptions to select.

Before
<img width="1437" alt="bfore" src="https://github.com/user-attachments/assets/509092c4-8127-489f-8d18-25d915ad1ef4" />

After
<img width="1435" alt="after" src="https://github.com/user-attachments/assets/d2277160-1550-44ec-8f1c-b3f9183386e6" />

no-docs
Closes #645