### PR TITLE
fix(Fee Validity): enable practitioner level fee validity

### DIFF
--- a/healthcare/healthcare/doctype/fee_validity/fee_validity.json
+++ b/healthcare/healthcare/doctype/fee_validity/fee_validity.json
@@ -38,6 +38,7 @@
    "fieldname": "patient",
    "fieldtype": "Link",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Patient",
    "options": "Patient",
    "read_only": 1,
@@ -121,9 +122,10 @@
    "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "in_create": 1,
  "links": [],
- "modified": "2023-04-09 10:40:36.311443",
+ "modified": "2025-05-09 19:31:19.874208",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Fee Validity",
@@ -144,6 +146,7 @@
  ],
  "quick_entry": 1,
  "restrict_to_domain": "Healthcare",
+ "row_format": "Dynamic",
  "search_fields": "practitioner, patient",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/healthcare/healthcare/doctype/healthcare_practitioner/healthcare_practitioner.json
+++ b/healthcare/healthcare/doctype/healthcare_practitioner/healthcare_practitioner.json
@@ -39,6 +39,10 @@
   "column_break_18",
   "inpatient_visit_charge_item",
   "inpatient_visit_charge",
+  "free_followup_details_section",
+  "enable_free_follow_ups",
+  "max_visits",
+  "valid_days",
   "account_details",
   "default_currency",
   "accounts",
@@ -353,11 +357,41 @@
    "fieldtype": "Link",
    "label": "Supplier",
    "options": "Supplier"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:doc.enable_free_follow_ups == 1",
+   "fieldname": "free_followup_details_section",
+   "fieldtype": "Section Break",
+   "label": "Free Followup Details"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_free_follow_ups",
+   "fieldtype": "Check",
+   "label": "Enable Free Follow-ups"
+  },
+  {
+   "depends_on": "eval:doc.enable_free_follow_ups == 1",
+   "description": "The number of free follow ups (Patient Encounters in valid days) allowed",
+   "fieldname": "max_visits",
+   "fieldtype": "Int",
+   "label": "Number of Patient Encounters in Valid Days",
+   "mandatory_depends_on": "eval:doc.enable_free_follow_ups == 1"
+  },
+  {
+   "depends_on": "eval:doc.enable_free_follow_ups == 1",
+   "description": "Time period (Valid number of days) for free consultations",
+   "fieldname": "valid_days",
+   "fieldtype": "Int",
+   "label": "Valid Number of Days",
+   "mandatory_depends_on": "eval:doc.enable_free_follow_ups == 1"
   }
  ],
+ "grid_page_length": 50,
  "image_field": "image",
  "links": [],
- "modified": "2023-03-04 18:33:25.753648",
+ "modified": "2025-05-08 12:35:22.089677",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Healthcare Practitioner",
@@ -404,6 +438,7 @@
  ],
  "quick_entry": 1,
  "restrict_to_domain": "Healthcare",
+ "row_format": "Dynamic",
  "search_fields": "practitioner_name, mobile_phone, office_phone",
  "show_name_in_global_search": 1,
  "sort_field": "modified",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -326,7 +326,7 @@ frappe.ui.form.on('Patient Appointment', {
 	toggle_payment_fields: function(frm) {
 		frappe.call({
 			method: 'healthcare.healthcare.doctype.patient_appointment.patient_appointment.check_payment_reqd',
-			args: { 'patient': frm.doc.patient },
+			args: { 'patient': frm.doc.patient, 'practitioner': frm.doc.practitoner },
 			callback: function(data) {
 				if (data.message.fee_validity) {
 					// if fee validity exists and show payment popup is enabled,
@@ -441,7 +441,10 @@ let check_and_set_availability = function(frm) {
 								} else {
 									frappe.call({
 										method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.update_fee_validity",
-										args: { "appointment": frm.doc }
+										args: { "appointment": frm.doc },
+										callback: (r) => {
+											frm.reload_doc();
+										}
 									});
 								}
 							}


### PR DESCRIPTION
- You can now configure free follow-ups at the practitioner level by enabling the `Enable Free Follow-ups` option in the Healthcare Practitioner.

![fee-validity](https://github.com/user-attachments/assets/34e11d2e-ef75-4201-88be-7137cee0967a)

- Creates Fee Validity based on the configuration in the Practitioner master. If `Enable Free Follow-ups` is not enabled for the practitioner, the setting will be fetched from `Healthcare Settings`.
