### PR TITLE
fix: required positional argument, closes #647

### DIFF
--- a/healthcare/public/js/sales_invoice.js
+++ b/healthcare/public/js/sales_invoice.js
@@ -3,6 +3,9 @@ frappe.ui.form.on('Sales Invoice', {
 	refresh(frm) {
 		if (frm.doc.docstatus === 0 && !frm.doc.is_return) {
 			frm.add_custom_button(__('Healthcare Services'), function() {
+				if (!frm.doc.patient) {
+					frappe.throw(__('Please select a Patient to be invoiced'));
+				}
 				frappe.db.get_value("Patient", frm.doc.patient, "customer")
 				.then(r => {
 					let link_customer = null;
@@ -21,6 +24,9 @@ frappe.ui.form.on('Sales Invoice', {
 				})
 			},__('Get Items From'));
 			frm.add_custom_button(__('Prescriptions'), function() {
+				if (!frm.doc.patient) {
+					frappe.throw(__('Please select a Patient to be invoiced'));
+				}
 				frappe.db.get_value("Patient", frm.doc.patient, "customer")
 				.then(r => {
 					let link_customer = null;


### PR DESCRIPTION
When a sales  invoice is created and no patient has been selected, then the following error occurs...
get_healthcare_services_to_invoice() missing 1 positional argument: 'customer'

This is because, in the "refresh" trigger, a frappe.db.get_value is executed without checking if "patient" contains
data. Fix is to first check if 'patient' contains data and prompt the user if there is no data.

This will close #647 

See attached screenshot for error message.
![sales_invoice_bug](https://github.com/user-attachments/assets/96639794-be47-40df-81ed-10408e8370f1)
