### PR TITLE
fix(Patient Encounter): include missing LOC for Google Meet link display on dashboard

### DIFF
--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -169,6 +169,14 @@ frappe.ui.form.on('Patient Encounter', {
 
 		frm.set_df_property('patient', 'read_only', frm.doc.appointment ? 1 : 0);
 
+		if (frm.doc.google_meet_link && frappe.datetime.now_date() <= frm.doc.encounter_date) {
+			frm.dashboard.set_headline(
+				__("Join video conference with {0}", [
+					`<a target='_blank' href='${frm.doc.google_meet_link}'>Google Meet</a>`,
+				])
+			);
+		}
+
 		if (frappe.meta.get_docfield('Drug Prescription', 'medication').in_list_view === 1) {
 			frm.set_query('drug_code', 'drug_prescription', function(doc, cdt, cdn) {
 				let row = frappe.get_doc(cdt, cdn);


### PR DESCRIPTION
- bring back Google Meet link display on Patient Encounter dashboard