### PR TITLE
fix: check develop branch compatibility with frappe branch

### DIFF
--- a/healthcare/hooks.py
+++ b/healthcare/hooks.py
@@ -79,7 +79,7 @@ jinja = {
 # Installation
 # ------------
 
-# before_install = "healthcare.install.before_install"
+before_install = "healthcare.install.before_install"
 after_install = "healthcare.setup.setup_healthcare"
 
 # Uninstallation

--- a/healthcare/install.py
+++ b/healthcare/install.py
@@ -1,0 +1,24 @@
+import click
+
+import frappe
+
+import healthcare
+
+
+def before_install():
+	def major_version(v: str) -> str:
+		return v.split(".")[0]
+
+	frappe_version = major_version(frappe.__version__)
+	healthcare_version = major_version(healthcare.__version__)
+
+	if frappe_version == healthcare_version:
+		return
+
+	click.secho(
+		f"You're attempting to install Marley Healthcare develop branch on Frappe and ERPNext version {frappe_version}."
+		"This is not supported and will result in broken install. Switch to correct branch before installing.",
+		fg="red",
+	)
+
+	raise SystemExit(1)

--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -1,4 +1,5 @@
 [pre_model_sync]
+healthcare.patches.v16_0.check_v16_compatibility_with_frappe
 healthcare.patches.v0_0.setup_abdm_custom_fields
 healthcare.patches.v0_0.set_medical_code_from_field_to_codification_table
 healthcare.patches.v15_0.check_version_compatibility_with_frappe

--- a/healthcare/patches/v16_0/check_v16_compatibility_with_frappe.py
+++ b/healthcare/patches/v16_0/check_v16_compatibility_with_frappe.py
@@ -1,0 +1,25 @@
+import click
+
+import frappe
+
+import healthcare
+
+
+def execute():
+	def major_version(v: str) -> str:
+		return v.split(".")[0]
+
+	frappe_version = major_version(frappe.__version__)
+	healthcare_version = major_version(healthcare.__version__)
+
+	WIKI_URL = "https://github.com/earthians/marley/wiki/Changes-to-branching-and-versioning"
+
+	if frappe_version == "15" and healthcare_version == "16":
+		message = f"""
+			The `develop` branch of Marley Health is no longer compatible with Frappe & ERPNext's `version-15`.
+			Since you are using ERPNext/Frappe `version-15` please switch Marley Health app's branch to `version-15` and then proceed with the update.\n\t
+			You can switch the branch by following the steps mentioned here: {WIKI_URL}
+		"""
+		click.secho(message, fg="red")
+
+		frappe.throw(message)  # nosemgrep


### PR DESCRIPTION
- The `develop` branch of Marley Health is no longer compatible with Frappe & ERPNext's `version-15`.
- Include patch to check the same