### PR TITLE
fix(Code Value Set): use value_set instead of code_value in autoname

### DIFF
--- a/healthcare/healthcare/doctype/code_value_set/code_value_set.py
+++ b/healthcare/healthcare/doctype/code_value_set/code_value_set.py
@@ -7,4 +7,4 @@ from frappe.model.document import Document
 
 class CodeValueSet(Document):
 	def autoname(self):
-		self.name = f"{self.code_value}-{self.code_system}"
+		self.name = f"{self.value_set}-{self.code_system}"


### PR DESCRIPTION
Issue:-

![image](https://github.com/user-attachments/assets/9c70c1e2-9d15-418e-87f5-ec4b318c58f8)

- Prevent server error by replacing undefined `code_value` with `value_set`
