### PR TITLE
fix(Patient Appointment): allow check-in and rescheduling for Department and Service Unit appointments

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -285,12 +285,14 @@ frappe.ui.form.on("Patient Appointment", {
 	department: function(frm) {
 		if (frm.doc.department && frm.doc.appointment_for == "Department") {
 			frm.events.set_payment_details(frm);
+			frm.set_value("appointment_based_on_check_in", 1);
 		}
 	},
 
 	service_unit: function(frm) {
 		if (frm.doc.service_unit && frm.doc.appointment_for == "Service Unit") {
 			frm.events.set_payment_details(frm);
+			frm.set_value("appointment_based_on_check_in", 1);
 		}
 	},
 

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -104,7 +104,11 @@ frappe.ui.form.on("Patient Appointment", {
 				update_status(frm, "Cancelled");
 			});
 			frm.add_custom_button(__("Reschedule"), function() {
-				check_and_set_availability(frm);
+				if (frm.doc.appointment_for == "Practitioner") {
+					check_and_set_availability(frm);
+				} else{
+					reschedule_dept_or_su(frm);
+				}
 			});
 
 			if (frm.doc.procedure_template) {
@@ -735,6 +739,49 @@ let check_and_set_availability = function(frm) {
 
 		return slot_html;
 	}
+};
+
+let reschedule_dept_or_su = function(frm) {
+	const is_department = frm.doc.appointment_for === "Department";
+
+	const field_config = {
+		fieldtype: "Link",
+		reqd: 1,
+		options: is_department ? "Medical Department" : "Healthcare Service Unit",
+		fieldname: is_department ? "department" : "service_unit",
+		label: is_department ? "Medical Department" : "Service Unit"
+	};
+
+	if (!is_department) {
+		field_config.get_query = function () {
+			return {
+				filters: { company: frm.doc.company }
+			};
+		};
+	}
+
+	let d = new frappe.ui.Dialog({
+		title: __("Reschedule Appointment"),
+		fields: [
+			field_config,
+			{ fieldtype: "Date", reqd: 1, fieldname: "appointment_date", label: "Date", min_date: new Date(frappe.datetime.get_today()) },
+		],
+		primary_action_label: __("Book"),
+		primary_action: function() {
+			const values = d.get_values();
+			if (values) {
+				frm.set_value(field_config.fieldname, values[field_config.fieldname]);
+				frm.set_value("appointment_date", values.appointment_date);
+			}
+
+			d.hide();
+			frm.enable_save();
+			frm.save();
+		}
+	});
+	d.set_value("appointment_date", frm.doc.appointment_date);
+	d.set_value(field_config.fieldname, frm.doc[field_config.fieldname]);
+	d.show();
 };
 
 let get_prescribed_procedure = function(frm) {

--- a/healthcare/healthcare/doctype/patient_appointment/test_patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/test_patient_appointment.py
@@ -592,6 +592,76 @@ class TestPatientAppointment(IntegrationTestCase):
 		# different practitioner can have multiple same time and date appointments for different patients
 		self.assertTrue(appointment_2.name)
 
+		# appointment booked for department
+		appointment_type = create_appointment_type(
+			args={
+				"name": "_Test Department",
+				"allow_booking_for": "Department",
+				"duration": 15,
+			}
+		)
+		medical_department = create_medical_department(id=2)
+		dept_appointment = create_appointment(
+			patient,
+			None,
+			nowdate(),
+			appointment_type=appointment_type,
+			appointment_for="Department",
+			department=medical_department,
+		)
+		self.assertTrue(dept_appointment.appointment_based_on_check_in)
+		dept_appointment.status = "Checked In"
+		dept_appointment.save()
+		self.assertEqual(dept_appointment.position_in_queue, 1)
+
+		dept_appointment_1 = create_appointment(
+			patient_1,
+			None,
+			nowdate(),
+			appointment_type=appointment_type,
+			appointment_for="Department",
+			department=medical_department,
+		)
+		self.assertTrue(dept_appointment_1.appointment_based_on_check_in)
+		dept_appointment_1.status = "Checked In"
+		dept_appointment_1.save()
+		self.assertEqual(dept_appointment_1.position_in_queue, 2)
+
+		# appointment booked for service unit
+		service_unit = create_service_unit(id=2)
+		appointment_type = create_appointment_type(
+			args={
+				"name": "_Test Service Unit",
+				"allow_booking_for": "Service Unit",
+				"duration": 15,
+			}
+		)
+		su_appointment = create_appointment(
+			patient,
+			None,
+			nowdate(),
+			appointment_type=appointment_type,
+			appointment_for="Service Unit",
+			service_unit=service_unit,
+		)
+		self.assertTrue(su_appointment.appointment_based_on_check_in)
+		su_appointment.status = "Checked In"
+		su_appointment.save()
+		self.assertEqual(su_appointment.position_in_queue, 1)
+
+		su_appointment_1 = create_appointment(
+			patient_1,
+			None,
+			nowdate(),
+			appointment_type=appointment_type,
+			appointment_for="Service Unit",
+			service_unit=service_unit,
+		)
+		self.assertTrue(su_appointment_1.appointment_based_on_check_in)
+		su_appointment_1.status = "Checked In"
+		su_appointment_1.save()
+		self.assertEqual(su_appointment_1.position_in_queue, 2)
+
 
 def create_healthcare_docs(id=0):
 	patient = create_patient(id)


### PR DESCRIPTION
- fix for reschedulling Department and Service Unit appointments using separate dialog
- allow check-in for these appointments
- tests to check these appointments can check-in

![checkin](https://github.com/user-attachments/assets/ecd1ec67-512b-4c00-afa5-8fcb518b669d)
