### PR TITLE
fix(Diagnostic Report): Enable bulk approve/reject for parent observation

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -165,13 +165,13 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Open\nPending Review\nPartially Approved\nApproved\nDisapproved",
+   "options": "Open\nPending Review\nPartially Approved\nApproved\nRejected",
    "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-02-19 18:41:30.142285",
+ "modified": "2025-06-04 18:41:30.142285",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Diagnostic Report",

--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
@@ -87,19 +87,19 @@ def set_observation_status(docname):
 				"sales_invoice": doc.docname,
 				"docstatus": ["!=", 2],
 				"has_component": False,
-				"status": ["not in", ["Cancelled", "Approved", "Disapproved"]],
+				"status": ["not in", ["Cancelled", "Approved", "Rejected"]],
 			},
 			pluck="name",
 		)
 		if observations:
 			for obs in observations:
-				if doc.status in ["Approved", "Disapproved"]:
+				if doc.status in ["Approved", "Rejected"]:
 					observation_doc = frappe.get_doc("Observation", obs)
 					if observation_doc.has_result():
-						if doc.status == "Approved" and not observation_doc.status in ["Approved", "Disapproved"]:
+						if doc.status == "Approved" and not observation_doc.status in ["Approved", "Rejected"]:
 							observation_doc.status = doc.status
 							observation_doc.save().submit()
-						if doc.status == "Disapproved" and observation_doc.status == "Approved":
+						if doc.status == "Rejected" and observation_doc.status == "Approved":
 							new_doc = frappe.copy_doc(observation_doc)
 							new_doc.status = ""
 							new_doc.insert()

--- a/healthcare/healthcare/doctype/observation/observation.json
+++ b/healthcare/healthcare/doctype/observation/observation.json
@@ -107,7 +107,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Registered\nPreliminary\nFinal\nAmended\nCorrected\nCancelled\nEntered in Error\nUnknown\nApproved\nDisapproved",
+   "options": "Registered\nPreliminary\nFinal\nAmended\nCorrected\nCancelled\nEntered in Error\nUnknown\nApproved\nRejected",
    "read_only_depends_on": "eval:doc.docstatus==1;"
   },
   {
@@ -569,7 +569,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-10-25 06:00:59.016090",
+ "modified": "2025-06-05 10:43:53.244291",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Observation",
@@ -577,6 +577,7 @@
  "owner": "Administrator",
  "permissions": [
   {
+   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -590,6 +591,7 @@
    "write": 1
   },
   {
+   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -599,9 +601,11 @@
    "report": 1,
    "role": "Healthcare Administrator",
    "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -52,7 +52,7 @@ class Observation(Document):
 			self.days = patient_doc.calculate_age().get("age_in_days")
 
 	def set_status(self):
-		if self.status not in ["Approved", "Disapproved"]:
+		if self.status not in ["Approved", "Rejected"]:
 			if self.has_result() and self.status != "Final":
 				self.status = "Preliminary"
 			elif self.amended_from and self.status not in ["Amended", "Corrected"]:
@@ -92,6 +92,15 @@ class Observation(Document):
 		# "result_period_to",
 
 		return False
+
+	def component_has_result(self):
+		component_obs = frappe.db.get_all("Observation", {"parent_observation": self.name}, pluck="name")
+		for obs in component_obs:
+			obs_doc = frappe.get_doc("Observation", obs)
+			if not obs_doc.has_result():
+				return False
+
+		return True
 
 	def validate_input(self):
 		if self.permitted_data_type in ["Quantity", "Numeric"]:
@@ -442,25 +451,50 @@ def get_observation_result_template(template_name, observation):
 
 
 @frappe.whitelist()
-def set_observation_status(observation, status, reason=None):
+def set_observation_status(observation, status, reason=None, parent_obs=None):
 	observation_doc = frappe.get_doc("Observation", observation)
-	if observation_doc.has_result():
-		observation_doc.status = status
-		if reason:
-			observation_doc.disapproval_reason = reason
-		if status == "Approved":
-			observation_doc.submit()
-		if status == "Disapproved":
-			new_doc = frappe.copy_doc(observation_doc)
-			new_doc.status = ""
-			new_doc.insert()
-			observation_doc.cancel()
-	else:
+
+	if not (observation_doc.has_result() or observation_doc.has_component):
 		frappe.throw(_("Please enter result to Approve."))
+
+	if observation_doc.has_component and not observation_doc.component_has_result():
+		frappe.throw(_("Please enter result for all components to Approve."))
+
+	observation_doc.status = status
+	if reason:
+		observation_doc.disapproval_reason = reason
+
+	if status == "Approved":
+		observation_doc.submit()
+	elif status == "Rejected":
+		new_doc = frappe.copy_doc(observation_doc)
+		new_doc.status = ""
+		new_doc.disapproval_reason = ""
+		if parent_obs:
+			new_doc.parent_observation = parent_obs
+		new_doc.insert()
+		if observation_doc.has_component:
+			parent_obs = new_doc.name
+		else:
+			observation_doc.cancel()
+
+	if observation_doc.has_component:
+		docstatus_filter = 0 if status == "Approved" else 1
+
+		component_obs = frappe.db.get_all(
+			"Observation",
+			filters={"parent_observation": observation, "docstatus": docstatus_filter},
+			pluck="name",
+		)
+
+		for obs in component_obs:
+			set_observation_status(obs, status, reason, parent_obs)
+		if status == "Rejected":
+			observation_doc.cancel()
 
 
 def set_diagnostic_report_status(doc):
-	if doc.has_result() and doc.sales_invoice and not doc.has_component and doc.sales_invoice:
+	if doc.sales_invoice and not doc.has_component:
 		observations = frappe.db.get_all(
 			"Observation",
 			{

--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -22,3 +22,4 @@ healthcare.patches.v15_0.setup_basic_code_systems
 healthcare.patches.v15_0.setup_diagnostic_module_codes
 healthcare.patches.v15_0.setup_order_status_codes
 healthcare.patches.v15_0.set_reference_in_therapy_plan
+healthcare.patches.v15_0.set_observation_and_diagnostic_report_status

--- a/healthcare/patches/v15_0/set_observation_and_diagnostic_report_status.py
+++ b/healthcare/patches/v15_0/set_observation_and_diagnostic_report_status.py
@@ -1,0 +1,13 @@
+import frappe
+
+
+def execute():
+	observations = frappe.db.get_all("Observation", filters={"status": "Disapproved"}, pluck="name")
+	for obs in observations:
+		frappe.db.set_value("Observation", obs, "status", "Rejected", update_modified=False)
+
+	diagnostic_reports = frappe.db.get_all(
+		"Diagnostic Report", filters={"status": "Disapproved"}, pluck="name"
+	)
+	for d in diagnostic_reports:
+		frappe.db.set_value("Diagnostic Report", d, "status", "Rejected", update_modified=False)

--- a/healthcare/public/js/observation_widget.js
+++ b/healthcare/public/js/observation_widget.js
@@ -12,23 +12,33 @@ healthcare.ObservationWidget = class {
 			if (!me.wrapper.find(`.${me.data.observation}`).length==0) {
 				return
 			}
+			console.log(me.data.obs_approved)
+			const is_approved = me.data.obs_approved;
+			var btn_action = is_approved ? "Rejected" : "Approved";
+			var btn_label = is_approved ? "Reject" : "Approve";
+
 			let grouped_html = (
-				`<div class="${me.data.observation} grouped-obs"
-					style="
-						border: 1px solid var(--border-color);
-						padding-right: 0;
-						font-size: 11px;
-						padding-left: 15px;
-						padding-top: 5px;
-						padding-bottom: 5px;
-						margin-bottom: 3px;
-						border-radius: 10px;
-						background-color:var(--bg-color);">
-						<b>
+				`<div class="${me.data.observation} grouped-obs" style="
+					border: 1px solid var(--border-color);
+					padding-right: 0;
+					font-size: 11px;
+					padding-left: 15px;
+					padding-top: 15px;
+					padding-bottom: 5px;
+					margin-bottom: 3px;
+					border-radius: 10px;
+					background-color:var(--bg-color);">
+					<b>
 						<a href="/app/observation/${me.data.observation}">
 							${me.data.display_name}
 						</a>
-						</b></div>`)
+					</b>
+					<div style="float:right; padding-right:5px; margin-top:-10px;">
+						<button class="btn btn-xs btn-secondary small obs-approve" id="authorise-observation-btn-${me.data.observation}">
+							<span style="font-size:10px;">${btn_label}</span>
+						</button>
+					</div>
+				</div>`)
 			me.wrapper.append(grouped_html)
 			let component_wrapper = me.wrapper.find(`.${me.data.observation}`)
 			for(var j=0, k=me.data[me.data.observation].length; j<k; j++) {
@@ -84,6 +94,12 @@ healthcare.ObservationWidget = class {
 			}
 		}
 		me.$widget = me.wrapper.find(`.grouped-obs`)
+		var authbutton = document.getElementById(`authorise-observation-btn-${me.data.observation}`);
+		if (authbutton) {
+			authbutton.addEventListener("click", function() {
+				me.auth_observation(me.data.observation, btn_action)
+			});
+		}
 	}
 
 	init_field_group(obs_data, wrapper) {
@@ -276,16 +292,15 @@ healthcare.ObservationWidget = class {
 		} else if (obs_data.status=='Approved') {
 			auth_html += `<div style="float:right;">
 				<button class="btn btn-xs btn-del btn-secondary small" id="unauthorise-observation-btn-${obs_data.name}">
-				<span class="btn-observ" style="font-size:10px;">Disapprove</span>
+				<span class="btn-observ" style="font-size:10px;">Reject</span>
 				</button>`
 			auth_html += `</div></div>`
 			me[obs_data.name].get_field('auth_btn').html(auth_html);
 			var authbutton = document.getElementById(`unauthorise-observation-btn-${obs_data.name}`);
 			authbutton.addEventListener("click", function() {
-				me.auth_observation(obs_data.name, "Disapproved")
+				me.auth_observation(obs_data.name, "Rejected")
 			});
 		}
-
 
 		let note_html = `<div><span class="add-note-observation-btn btn btn-link"
 			id="add-note-observation-btn-${obs_data.name}">
@@ -384,9 +399,9 @@ healthcare.ObservationWidget = class {
 					}
 				});
 			})
-		} else if (status == "Disapproved") {
+		} else if (status == "Rejected") {
 			var d = new frappe.ui.Dialog({
-				title: __('Reason For Disapproval'),
+				title: __('Reason For Rejection'),
 				fields: [
 					{
 						"label": __("Reason"),
@@ -413,9 +428,9 @@ healthcare.ObservationWidget = class {
 						}
 					});
 				},
-				primary_action_label: __("Disapprove")
-				});
-				d.show()
+				primary_action_label: __("Reject")
+			});
+			d.show()
 		}
 
 	}


### PR DESCRIPTION
- Enable bulk approval/rejection actions for parent observations
- Standardized status option by renaming `Disapproved` to `Rejected`
- Patch to update existing records with status `Disapproved` to `Rejected` in both Observation and Diagnostic Report doctypes.

![diag-approve](https://github.com/user-attachments/assets/08459efb-867f-4e75-9960-862838bc18c6)

![diag-reject](https://github.com/user-attachments/assets/366d4fb4-31e7-4ef4-94fb-f66daa48f9c1)

