### PR TITLE
fix(Patient): Handle None mobile number in duplicate user check

### DIFF
--- a/healthcare/healthcare/doctype/patient/patient.py
+++ b/healthcare/healthcare/doctype/patient/patient.py
@@ -103,18 +103,26 @@ class Patient(Document):
 			self.language = frappe.db.get_single_value("System Settings", "language")
 
 	def create_website_user(self):
+		filters = {"email": self.email}
+		if self.mobile:
+			filters["mobile_no"] = self.mobile
 		users = frappe.db.get_all(
 			"User",
 			fields=["email", "mobile_no"],
-			or_filters={"email": self.email, "mobile_no": self.mobile},
+			or_filters=filters,
 		)
+
 		if users and users[0]:
-			frappe.throw(
-				_(
-					"User exists with Email {}, Mobile {}<br>Please check email / mobile or disable 'Invite as User' to skip creating User"
-				).format(frappe.bold(users[0].email), frappe.bold(users[0].mobile_no)),
-				frappe.DuplicateEntryError,
+			message = _("User exists with Email {}").format(frappe.bold(users[0].email))
+
+			if users[0].mobile_no:
+				message += _(", Mobile {}").format(frappe.bold(users[0].mobile_no))
+
+			message += _(
+				"<br>Please check email / mobile or disable 'Invite as User' to skip creating User"
 			)
+
+			frappe.throw(message, frappe.DuplicateEntryError)
 
 		user = frappe.get_doc(
 			{


### PR DESCRIPTION
issue-
- When a Patient is inserted, the system checks for duplicate users using the email and mobile number if invite_user is enabled, but fails if the mobile number is `None`.

![Screenshot from 2025-06-06 17-20-35](https://github.com/user-attachments/assets/627d8f6a-799d-4417-a372-e0863b6eaea1)
