### PR TITLE
fix: exclude observations linked to sales invoice and child observations in Sales Invoice

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -442,6 +442,8 @@ def get_observations_to_invoice(patient, company):
 			"invoiced": False,
 			"docstatus": 1,
 			"service_request": "",
+			"sales_invoice": None,
+			"parent_observation": None,
 		},
 	)
 	for observation in observations:
@@ -1566,10 +1568,12 @@ def create_sample_collection_and_observation(doc):
 
 		# ignore if already created from service request
 		if item.get("reference_dt") == "Service Request" and item.get("reference_dn"):
-			if frappe.db.exists(
-				"Observation Sample Collection", {"service_request": item.get("reference_dn")}
-			) or frappe.db.exists(
-				"Sample Collection", {"service_request": item.get("reference_dn")}
+			if (
+				frappe.db.exists(
+					"Observation Sample Collection", {"service_request": item.get("reference_dn")}
+				)
+				or frappe.db.exists("Sample Collection", {"service_request": item.get("reference_dn")})
+				or frappe.db.exists("Observation", {"service_request": item.get("reference_dn")})
 			):
 				continue
 


### PR DESCRIPTION
Updated the Get Items From `Healthcare Services` feature to ensure it only fetches valid, billable observations.
- Child observations are now excluded
- Observations already linked to a Sales Invoice are no longer fetched