### PR TITLE
fix: encounter doesn't update medical codes on diagnosis change

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1544,6 +1544,7 @@ def get_medical_codes(template_dt, template_dn, code_standard=None):
 			"code_value",
 			"code",
 			"system",
+			"display",
 			"definition",
 			"code_system",
 		],


### PR DESCRIPTION
- Patient Encounter - update codification table on diagnosis change
- get_medical_codes to fetch the `display` field as well