### PR TITLE
fix(Inpatient Record): fix billing calculation for inpatient occupancy

### DIFF
--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -13,6 +13,7 @@ healthcare.patches.v15_0.add_observation_to_patient_history
 healthcare.patches.v15_0.create_patient_medical_records_for_observations #25-12-2024
 healthcare.patches.v15_0.add_discharge_summary_to_patient_history
 healthcare.patches.v16_0.setup_service_request_and_insurance
+healthcare.patches.v16_0.validate_inpatient_billables
 
 [post_model_sync]
 healthcare.patches.v15_0.rename_field_medical_department_in_appoitment_type_service_item

--- a/healthcare/patches/v16_0/validate_inpatient_billables.py
+++ b/healthcare/patches/v16_0/validate_inpatient_billables.py
@@ -1,0 +1,12 @@
+import frappe
+
+
+def execute():
+	inpatient_records = frappe.get_all(
+		"Inpatient Record", {"status": ("in", ["Admitted", "Discharge Scheduled"])}
+	)
+
+	for inpatient_record in inpatient_records:
+		frappe.get_doc(
+			"Inpatient Record", inpatient_record.name
+		).add_service_unit_rent_to_billable_items()


### PR DESCRIPTION
- Fixed the incorrect calculation of Inpatient Record Item when the UOM is not "Hour".
- Ensured the rate is fetched correctly from the defined Service Unit Type when invoicing.
- Added a patch to trigger the generation of billable items.