### PR TITLE
feat: get orders in Patient Appointment to replace get prescriptions

### DIFF
--- a/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
+++ b/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
@@ -44,8 +44,9 @@ frappe.ui.form.on('Clinical Procedure', {
 		frm.set_query('appointment', function () {
 			return {
 				filters: {
-					'procedure_template': ['not in', null],
-					'status': ['in', 'Open, Scheduled']
+					'template_dt': 'Clinical Procedure Template',
+					'template_dn': frm.doc.procedure_template,
+					'status': ['in', ['Open', 'Scheduled']]
 				}
 			};
 		});
@@ -223,7 +224,7 @@ frappe.ui.form.on('Clinical Procedure', {
 				callback: function(data) {
 					let values = {
 						'patient':data.message.patient,
-						'procedure_template': data.message.procedure_template,
+						'procedure_template': data.message.template_dn,
 						'medical_department': data.message.department,
 						'practitioner': data.message.practitioner,
 						'start_date': data.message.appointment_date,

--- a/healthcare/healthcare/doctype/observation/observation.js
+++ b/healthcare/healthcare/doctype/observation/observation.js
@@ -2,6 +2,23 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Observation", {
+	refresh: function(frm) {
+		frm.set_query("patient", function () {
+			return {
+				filters: {"status": ["!=", "Disabled"]}
+			};
+		});
+
+		frm.set_query("appointment", function () {
+			return {
+				filters: {
+					"template_dt": "Observation Template",
+					"template_dn": frm.doc.observation_template,
+					"status": ["in", ["Open", "Scheduled"]]
+				}
+			};
+		});
+	},
 	onload_post_render: function(frm) {
 		frm.trigger("set_options");
 	},
@@ -16,9 +33,9 @@ frappe.ui.form.on("Observation", {
 
 	set_options: function(frm) {
 		if (frm.doc.permitted_data_type == "Select") {
-			frm.set_df_property('result_select', 'options', frm.doc.options);
+			frm.set_df_property("result_select", "options", frm.doc.options);
 		} else if (frm.doc.permitted_data_type == "Boolean") {
-			frm.set_df_property('result_boolean', 'options', frm.doc.options);
+			frm.set_df_property("result_boolean", "options", frm.doc.options);
 		}
 	},
 

--- a/healthcare/healthcare/doctype/observation/observation.json
+++ b/healthcare/healthcare/doctype/observation/observation.json
@@ -13,6 +13,7 @@
   "naming_series",
   "observation_template",
   "observation_category",
+  "appointment",
   "column_break_7xu5",
   "company",
   "posting_date",
@@ -564,12 +565,18 @@
    "fieldtype": "Check",
    "label": "Invoiced",
    "read_only": 1
+  },
+  {
+   "fieldname": "appointment",
+   "fieldtype": "Link",
+   "label": "Appointment",
+   "options": "Patient Appointment"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-05 10:43:53.244291",
+ "modified": "2025-06-29 23:04:47.368632",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Observation",

--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -35,6 +35,10 @@ class Observation(Document):
 	def before_insert(self):
 		set_observation_idx(self)
 
+	def after_insert(self):
+		if self.appointment:
+			frappe.db.set_value("Patient Appointment", self.appointment, "status", "Closed")
+
 	def on_submit(self):
 		if self.service_request:
 			frappe.db.set_value(

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -464,7 +464,7 @@ frappe.ui.form.on("Patient Appointment", {
 		}
 
 		const d = new frappe.ui.Dialog({
-			title: 'Select a Service Request',
+			title: __('Select a Service Request'),
 			fields: [
 				{
 					fieldname: 'service_html',
@@ -477,21 +477,35 @@ frappe.ui.form.on("Patient Appointment", {
 					`
 				}
 			],
-			primary_action_label: 'Select',
+			primary_action_label: __('Select'),
 			primary_action() {
 				const selected = d.$wrapper.find('.service-row[data-selected="true"]')[0];
 				if (!selected) {
 					frappe.msgprint(__("Please select a service request."));
 					return;
 				}
+
 				const selected_id = selected.dataset.name;
-				frm.set_value("service_request", selected_id);
-				frappe.db.get_value("Service Request", selected_id, ["template_dt", "template_dn"]).then(r => {
-					frm.set_value({
-						"template_dt": r.message.template_dt,
-						"template_dn": r.message.template_dn
+				if (selected_id) {
+					frappe.db.get_doc("Service Request", selected_id)
+					.then(doc => {
+						frm.set_value({
+							"service_request": selected_id,
+							"template_dt": doc.template_dt,
+							"template_dn": doc.template_dn,
+							"referring_practitioner": doc.practitioner,
+							"notes": doc.order_description
+						});
+
+						if (doc.template_dt == "Appointment Type" && doc.template_dn) {
+							frm.set_value({
+								"appointment_type": doc.template_dn,
+								"practitioner": doc.referred_to_practitioner
+							});
+						}
 					})
-				})
+				}
+
 				d.hide();
 			}
 		});

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -481,7 +481,7 @@ frappe.ui.form.on("Patient Appointment", {
 			primary_action() {
 				const selected = d.$wrapper.find('.service-row[data-selected="true"]')[0];
 				if (!selected) {
-					frappe.msgprint("Please select a service request.");
+					frappe.msgprint(__("Please select a service request."));
 					return;
 				}
 				const selected_id = selected.dataset.name;
@@ -606,7 +606,7 @@ frappe.ui.form.on("Patient Appointment", {
 						indicator = "green"
 					}
 					frappe.show_alert({
-						message: __("{0}", [title]),
+						message: __(title),
 						indicator: indicator,
 					});
 					frappe.set_route('Form', r.message[1], r.message[0]);

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -319,6 +319,13 @@ frappe.ui.form.on("Patient Appointment", {
 			frm.set_value("patient_age", "");
 			frm.set_value("inpatient_record", "");
 		}
+		if (frm.doc.template_dt && frm.doc.template_dn) {
+			frm.set_value({
+				"template_dt": "",
+				"template_dn": "",
+				"service_request": ""
+			});
+		}
 	},
 
 	practitioner: function(frm) {

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -502,7 +502,9 @@ frappe.ui.form.on("Patient Appointment", {
 			fields: [
 				"name",
 				"order_group",
+				"order_date",
 				"practitioner",
+				"practitioner_name",
 				"template_dt",
 				"template_dn",
 				"status",
@@ -1388,16 +1390,15 @@ let get_service_request_list_html = function (data) {
 
 		html += `
 			<div class="service-row"
-				 data-name="${row.name}"
-				 data-selected="false"
-				 style="
-					border: 1px solid #dddaaa;
-					border-radius: 6px;
-					padding: 12px;
-					cursor: pointer;
-					transition: all 0.2s ease-in-out;
-				 ">
-				<!-- Top row: ServiceType: <b>ServiceName</b> + Badge -->
+				data-name="${row.name}"
+				data-selected="false"
+				style="
+				border: 1px solid #dddaaa;
+				border-radius: 6px;
+				padding: 12px;
+				cursor: pointer;
+				transition: all 0.2s ease-in-out;
+			">
 				<div style="display: flex; justify-content: space-between; align-items: center;">
 					<div style="font-size: 1rem;">
 						${service_type}: <b>${row.template_dn || ''}</b>
@@ -1405,10 +1406,15 @@ let get_service_request_list_html = function (data) {
 					<span class="indicator ${status_clr}">${status_txt}</span>
 				</div>
 
-				<!-- Second row: order_group and practitioner -->
 				<div style="display: flex; justify-content: space-between; margin-top: 5px; font-size: 0.875rem; color: #4b4b4b;">
-					<div>${row.order_group || ''}</div>
-					<div>${row.practitioner || ''}</div>
+					<div style="display: flex; flex-direction: column; align-items: flex-start; text-align: left;">
+						<div>${row.order_group || ''}</div>
+						<div style="color: gray;">${frappe.datetime.str_to_user(row.order_date) || ''}</div>
+					</div>
+					<div style="display: flex; flex-direction: column; align-items: flex-end; text-align: right;">
+						<div>${row.practitioner || ''}</div>
+						<div style="color: gray;">${row.practitioner_name || ''}</div>
+					</div>
 				</div>
 			</div>
 		`;

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -48,6 +48,9 @@
   "therapy_plan",
   "therapy_type",
   "get_prescribed_therapies",
+  "template_dt",
+  "template_dn",
+  "get_orders",
   "column_break_17",
   "appointment_time",
   "appointment_datetime",
@@ -128,6 +131,7 @@
    "depends_on": "eval:doc.patient",
    "fieldname": "procedure_template",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Clinical Procedure Template",
    "options": "Clinical Procedure Template",
    "set_only_once": 1
@@ -136,6 +140,7 @@
    "depends_on": "eval:doc.__islocal && doc.patient",
    "fieldname": "get_procedure_from_encounter",
    "fieldtype": "Button",
+   "hidden": 1,
    "label": "Get Prescribed Clinical Procedures"
   },
   {
@@ -317,6 +322,7 @@
    "depends_on": "eval:doc.patient && doc.therapy_plan;",
    "fieldname": "therapy_type",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Therapy",
    "options": "Therapy Type",
    "set_only_once": 1
@@ -325,12 +331,14 @@
    "depends_on": "eval:doc.patient && doc.therapy_plan && doc.__islocal;",
    "fieldname": "get_prescribed_therapies",
    "fieldtype": "Button",
+   "hidden": 1,
    "label": "Get Prescribed Therapies"
   },
   {
    "depends_on": "eval: doc.patient;",
    "fieldname": "therapy_plan",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Therapy Plan",
    "options": "Therapy Plan",
    "set_only_once": 1
@@ -516,11 +524,32 @@
   {
    "fieldname": "column_break_gdcb",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "template_dt",
+   "fieldtype": "Link",
+   "label": "Template DocType",
+   "options": "DocType",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "template_dn",
+   "fieldtype": "Dynamic Link",
+   "label": "Template DocName",
+   "options": "template_dt",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "get_orders",
+   "fieldtype": "Button",
+   "label": "Get Orders"
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-04-22 14:44:17.881699",
+ "modified": "2025-06-30 15:34:01.767364",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Patient Appointment",

--- a/healthcare/healthcare/doctype/patient_medical_record/test_patient_medical_record.py
+++ b/healthcare/healthcare/doctype/patient_medical_record/test_patient_medical_record.py
@@ -11,6 +11,7 @@ from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profi
 
 from healthcare.healthcare.doctype.patient_appointment.test_patient_appointment import (
 	create_appointment,
+	create_clinical_procedure_template,
 	create_encounter,
 	create_healthcare_docs,
 	create_medical_department,
@@ -42,8 +43,9 @@ class TestPatientMedicalRecord(IntegrationTestCase):
 		)
 		self.assertTrue(medical_rec)
 
+		procedure_template = create_clinical_procedure_template().get("name")
 		appointment = create_appointment(
-			patient, practitioner, add_days(nowdate(), 1), invoice=1, procedure_template=1
+			patient, practitioner, add_days(nowdate(), 1), invoice=1, procedure_template=procedure_template
 		)
 		procedure = create_procedure(appointment)
 		procedure.start_procedure()
@@ -66,7 +68,7 @@ class TestPatientMedicalRecord(IntegrationTestCase):
 def create_procedure(appointment):
 	if appointment:
 		procedure = frappe.new_doc("Clinical Procedure")
-		procedure.procedure_template = appointment.procedure_template
+		procedure.procedure_template = appointment.template_dn
 		procedure.appointment = appointment.name
 		procedure.patient = appointment.patient
 		procedure.practitioner = appointment.practitioner

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.json
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.json
@@ -14,6 +14,7 @@
   "patient_name",
   "patient_age",
   "patient_sex",
+  "appointment",
   "referring_practitioner",
   "column_break_4",
   "company",
@@ -295,6 +296,12 @@
    "options": "Sample Collection",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "appointment",
+   "fieldtype": "Link",
+   "label": "Appointment",
+   "options": "Patient Appointment"
   }
  ],
  "is_submittable": 1,
@@ -304,7 +311,7 @@
    "link_fieldname": "sample_collection"
   }
  ],
- "modified": "2024-03-19 15:33:50.056780",
+ "modified": "2025-06-29 23:05:21.880616",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Sample Collection",
@@ -339,6 +346,7 @@
   }
  ],
  "restrict_to_domain": "Healthcare",
+ "row_format": "Dynamic",
  "search_fields": "patient, sample",
  "show_name_in_global_search": 1,
  "sort_field": "modified",

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -30,6 +30,9 @@ class SampleCollection(Document):
 							},
 						)
 
+		if self.appointment:
+			frappe.db.set_value("Patient Appointment", self.appointment, "status", "Closed")
+
 	def validate(self):
 		if self.observation_sample_collection:
 			for obs in self.observation_sample_collection:

--- a/healthcare/healthcare/doctype/service_request/service_request.js
+++ b/healthcare/healthcare/doctype/service_request/service_request.js
@@ -203,7 +203,7 @@ frappe.ui.form.on('Service Request', {
 	make_clinical_procedure: function(frm) {
 		frappe.call({
 			method: 'healthcare.healthcare.doctype.service_request.service_request.make_clinical_procedure',
-			args: { service_request: frm.doc },
+			args: { service_request: frm.doc.name },
 			freeze: true,
 			callback: function(r) {
 				var doclist = frappe.model.sync(r.message);
@@ -215,7 +215,7 @@ frappe.ui.form.on('Service Request', {
 	make_lab_test: function(frm) {
 		frappe.call({
 			method: 'healthcare.healthcare.doctype.service_request.service_request.make_lab_test',
-			args: { service_request: frm.doc },
+			args: { service_request: frm.doc.name },
 			freeze: true,
 			callback: function(r) {
 				var doclist = frappe.model.sync(r.message);
@@ -244,7 +244,7 @@ frappe.ui.form.on('Service Request', {
 	make_observation: function(frm) {
 		frappe.call({
 			method: 'healthcare.healthcare.doctype.service_request.service_request.make_observation',
-			args: { service_request: frm.doc },
+			args: { service_request: frm.doc.name },
 			freeze: true,
 			callback: function(r) {
 				if (r.message) {

--- a/healthcare/healthcare/doctype/service_request/service_request.json
+++ b/healthcare/healthcare/doctype/service_request/service_request.json
@@ -31,6 +31,7 @@
   "inpatient_status",
   "order_source_section",
   "practitioner",
+  "practitioner_name",
   "practitioner_email",
   "medical_department",
   "referred_to_practitioner",
@@ -594,6 +595,12 @@
    "fieldtype": "Duration",
    "hide_seconds": 1,
    "label": "Interval"
+  },
+  {
+   "fetch_from": "practitioner.practitioner_name",
+   "fieldname": "practitioner_name",
+   "fieldtype": "Data",
+   "label": "Ordered by Practitioner Name"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -612,7 +619,7 @@
    "link_fieldname": "service_request"
   }
  ],
- "modified": "2025-05-15 12:58:58.427869",
+ "modified": "2025-07-18 20:36:56.162647",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Service Request",
@@ -669,6 +676,7 @@
  "search_fields": "title,patient,order_group,inpatient_record,practitioner,patient_email,patient_mobile",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "title",
  "track_changes": 1,
  "track_seen": 1,

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -349,7 +349,7 @@ def make_observation(service_request, appointment=None):
 		"Diagnostic Report", {"reference_name": service_request.order_group}
 	)
 	if not diagnostic_report:
-		insert_diagnostic_report(service_request, sample_collection)
+		insert_diagnostic_report(service_request, sample_collection.name)
 
 	if sample_collection:
 		return sample_collection.name, "Sample Collection"
@@ -399,9 +399,6 @@ def create_observation(service_request, appointment=None):
 
 
 def insert_diagnostic_report(doc, sample_collection=None):
-	if isinstance(sample_collection, dict):
-		sample_collection = sample_collection.name
-
 	diagnostic_report = frappe.new_doc("Diagnostic Report")
 	diagnostic_report.company = doc.company
 	diagnostic_report.patient = doc.patient

--- a/healthcare/healthcare/doctype/service_request/test_service_request.py
+++ b/healthcare/healthcare/doctype/service_request/test_service_request.py
@@ -73,7 +73,7 @@ class TestServiceRequest(IntegrationTestCase):
 						test.descriptive_test_items[2].result_value = 3
 						test.submit()
 					elif sr.get("template_dt") == "Clinical Procedure Template":
-						test = make_clinical_procedure(service_request_doc)
+						test = make_clinical_procedure(service_request_doc.name)
 						test.submit()
 						doc = "Clinical Procedure"
 						template = procedure_template

--- a/healthcare/healthcare/doctype/therapy_plan/therapy_plan.py
+++ b/healthcare/healthcare/doctype/therapy_plan/therapy_plan.py
@@ -62,7 +62,13 @@ class TherapyPlan(Document):
 
 @frappe.whitelist()
 def make_therapy_session(
-	patient, therapy_type, company, therapy_plan=None, appointment=None, service_request=None
+	patient,
+	therapy_type,
+	company,
+	therapy_plan=None,
+	appointment=None,
+	service_request=None,
+	practitioner=None,
 ):
 	sr_doc = None
 	if service_request:
@@ -94,6 +100,12 @@ def make_therapy_session(
 	therapy_session.therapy_plan = therapy_plan
 	therapy_session.company = company
 	therapy_session.patient = patient
+	therapy_session.practitioner = practitioner
+	therapy_session.department = (
+		frappe.get_cached_value("Healthcare Practitioner", practitioner, "department")
+		if practitioner
+		else ""
+	)
 	therapy_session.therapy_type = therapy_type.name
 	therapy_session.duration = therapy_type.default_duration
 	therapy_session.rate = therapy_type.rate

--- a/healthcare/healthcare/doctype/therapy_session/therapy_session.js
+++ b/healthcare/healthcare/doctype/therapy_session/therapy_session.js
@@ -24,6 +24,8 @@ frappe.ui.form.on('Therapy Session', {
 
 			return {
 				filters: {
+					"template_dt": "Therapy Type",
+					"template_dn": frm.doc.therapy_type,
 					'status': ['in', ['Open', 'Scheduled']]
 				}
 			};
@@ -148,7 +150,7 @@ frappe.ui.form.on('Therapy Session', {
 				callback: function(data) {
 					let values = {
 						'patient':data.message.patient,
-						'therapy_type': data.message.therapy_type,
+						'therapy_type': data.message.template_dn,
 						'therapy_plan': data.message.therapy_plan,
 						'practitioner': data.message.practitioner,
 						'department': data.message.department,

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -79,15 +79,13 @@ def get_appointments_to_invoice(patient, company):
 	for appointment in patient_appointments:
 		# Procedure Appointments
 		# TODO: insurance? do we need this?
-		if appointment.procedure_template:
-			if frappe.db.get_value(
-				"Clinical Procedure Template", appointment.procedure_template, "is_billable"
-			):
+		if appointment.template_dt and appointment.template_dn:
+			if frappe.db.get_value(appointment.template_dt, appointment.template_dn, "is_billable"):
 				appointments_to_invoice.append(
 					{
 						"reference_type": "Patient Appointment",
 						"reference_name": appointment.name,
-						"service": appointment.procedure_template,
+						"service": frappe.db.get_value(appointment.template_dt, appointment.template_dn, "item"),
 					}
 				)
 		# Consultation Appointments, should check fee validity

--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -24,3 +24,4 @@ healthcare.patches.v15_0.setup_diagnostic_module_codes
 healthcare.patches.v15_0.setup_order_status_codes
 healthcare.patches.v15_0.set_reference_in_therapy_plan
 healthcare.patches.v15_0.set_observation_and_diagnostic_report_status
+healthcare.patches.v16_0.set_template_dn_and_template_dt_in_appointment

--- a/healthcare/patches/v16_0/set_template_dn_and_template_dt_in_appointment.py
+++ b/healthcare/patches/v16_0/set_template_dn_and_template_dt_in_appointment.py
@@ -1,0 +1,29 @@
+import frappe
+
+
+def execute():
+	# Update appointments with procedure_template
+	update_template_links(
+		doctype="Patient Appointment",
+		source_field="procedure_template",
+		template_dt="Clinical Procedure Template",
+	)
+
+	# Update appointments with therapy_type
+	update_template_links(
+		doctype="Patient Appointment", source_field="therapy_type", template_dt="Therapy Type"
+	)
+
+
+def update_template_links(doctype, source_field, template_dt):
+	records = frappe.db.get_all(
+		doctype, filters={source_field: ["is", "set"]}, fields=["name", source_field]
+	)
+
+	for record in records:
+		frappe.db.set_value(
+			doctype,
+			record.name,
+			{"template_dt": template_dt, "template_dn": record[source_field]},
+			update_modified=False,
+		)


### PR DESCRIPTION
docs - [Documentation](https://marley.frappe.cloud/wiki/patient-appointment#38-book-appointment-for-orders)

- Instead of using multiple fields for therapy and clinical proceedure, you can now use the `Get Orders` button to quickly link any service request to an appointment, that includes Observations too.

### How it works:

1. Click the `Get Orders` button in the Patient Appointment form after selecting the patient.
2. A dialog will appear showing all pending service requests for the selected patient.
3. Choose a service request from the list.
4. Once selected, the system will automatically fetch the template type, template name, and the linked service request.
5. From there you can book an appointment against the selected request
6. Under the `Create` button you can create related documents.

![get-orders-dialog](https://github.com/user-attachments/assets/aa22ebc2-128c-4d1d-ba97-bd428618954f)

![get-orders](https://github.com/user-attachments/assets/6fcd8b09-e9f1-4a50-a3b7-dc556a846cdc)
