### PR TITLE
fix: handle HSN/SAC update in healthcare templates that are linked to item

### DIFF
--- a/healthcare/healthcare/doctype/clinical_procedure_template/clinical_procedure_template.js
+++ b/healthcare/healthcare/doctype/clinical_procedure_template/clinical_procedure_template.js
@@ -2,32 +2,17 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Clinical Procedure Template', {
+	setup: function (frm) {
+		if (frappe.meta.has_field(frm.doc.doctype, "gst_hsn_code")) {
+			frm.add_fetch("item", "gst_hsn_code", "gst_hsn_code");
+		}
+	},
+
 	template: function (frm) {
 		if (!frm.doc.item_code)
 			frm.set_value('item_code', frm.doc.template);
 		if (!frm.doc.description)
 			frm.set_value('description', frm.doc.template);
-		mark_change_in_item(frm);
-	},
-
-	rate: function (frm) {
-		mark_change_in_item(frm);
-	},
-
-	is_billable: function (frm) {
-		mark_change_in_item(frm);
-	},
-
-	item_group: function (frm) {
-		mark_change_in_item(frm);
-	},
-
-	description: function (frm) {
-		mark_change_in_item(frm);
-	},
-
-	medical_department: function (frm) {
-		mark_change_in_item(frm);
 	},
 
 	refresh: function (frm) {
@@ -90,12 +75,6 @@ frappe.ui.form.on('Clinical Procedure Template', {
 		}
 	}
 });
-
-let mark_change_in_item = function (frm) {
-	if (!frm.doc.__islocal || frm.doc.link_existing_item) {
-		frm.doc.change_in_item = 1;
-	}
-};
 
 let change_template_code = function (doc) {
 	let d = new frappe.ui.Dialog({

--- a/healthcare/healthcare/doctype/clinical_procedure_template/clinical_procedure_template.py
+++ b/healthcare/healthcare/doctype/clinical_procedure_template/clinical_procedure_template.py
@@ -29,7 +29,18 @@ class ClinicalProcedureTemplate(Document):
 			create_item_from_template(self)
 
 	def on_update(self):
-		if self.change_in_item:
+		doc_before_save = self.get_doc_before_save()
+		if not doc_before_save:
+			return
+		if (
+			doc_before_save.template != self.template
+			or doc_before_save.rate != self.rate
+			or doc_before_save.is_billable != self.is_billable
+			or doc_before_save.item_group != self.item_group
+			or doc_before_save.description != self.description
+			or doc_before_save.medical_department != self.medical_department
+			or doc_before_save.get("gst_hsn_code") != self.get("gst_hsn_code")
+		):
 			update_item_and_item_price(self)
 
 	def enable_disable_item(self):
@@ -145,5 +156,3 @@ def update_item_and_item_price(doc):
 
 	elif not doc.is_billable and doc.item and not doc.link_existing_item:
 		frappe.db.set_value("Item", doc.item, "disabled", 1)
-
-	doc.db_set("change_in_item", 0)

--- a/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.js
+++ b/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.js
@@ -18,31 +18,11 @@ frappe.ui.form.on('Healthcare Service Unit Type', {
 
 	service_unit_type: function(frm) {
 		set_item_details(frm);
-
-		if (!frm.doc.__islocal) {
-			frm.doc.change_in_item = 1;
-		}
 	},
 
 	is_billable: function(frm) {
 		set_item_details(frm);
 	},
-
-	rate: function(frm) {
-		if (!frm.doc.__islocal) {
-			frm.doc.change_in_item = 1;
-		}
-	},
-	item_group: function(frm) {
-		if (!frm.doc.__islocal) {
-			frm.doc.change_in_item = 1;
-		}
-	},
-	description: function(frm) {
-		if (!frm.doc.__islocal) {
-			frm.doc.change_in_item = 1;
-		}
-	}
 });
 
 let set_item_details = function(frm) {

--- a/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.py
+++ b/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.py
@@ -142,7 +142,7 @@ def update_item(doc):
 				"description": doc.description,
 			}
 		)
-		item.db_update()
+		item.save(ignore_permissions=True)
 
 
 @frappe.whitelist()

--- a/healthcare/healthcare/doctype/medication/medication.js
+++ b/healthcare/healthcare/doctype/medication/medication.js
@@ -67,6 +67,10 @@ frappe.ui.form.on("Medication Linked Item", {
 	description: function(frm, cdt, cdn) {
 		mark_change_in_item(frm, cdt, cdn);
 	},
+
+	gst_hsn_code: function(frm, cdt, cdn) {
+		mark_change_in_item(frm, cdt, cdn);
+	},
 })
 
 let mark_change_in_item = function(frm, cdt, cdn) {

--- a/healthcare/healthcare/doctype/medication/medication.py
+++ b/healthcare/healthcare/doctype/medication/medication.py
@@ -62,6 +62,8 @@ class Medication(Document):
 						item_doc.manufacturer = item.manufacturer
 						item_doc.brand = item.brand
 						item_doc.disabled = 0
+						if item.get("gst_hsn_code"):
+							item_doc.gst_hsn_code = item.get("gst_hsn_code")
 						item_doc.save(ignore_permissions=True)
 						if item.rate:
 							item_price = frappe.db.exists(
@@ -76,7 +78,6 @@ class Medication(Document):
 								item_price.price_list_rate = item.rate
 								item_price.price_list = self.price_list
 								item_price.save()
-
 				else:
 					frappe.db.set_value("Item", item.item_code, "disabled", 1)
 
@@ -104,7 +105,7 @@ def insert_item(doc, item):
 				"disabled": 0 if item.is_billable and not doc.disabled else 1,
 				"stock_uom": item.stock_uom or frappe.db.get_single_value("Stock Settings", "stock_uom"),
 			}
-		).insert(ignore_permissions=True, ignore_mandatory=True)
+		)
 	else:
 		item_doc = frappe.get_doc("Item", item.item_code)
 		if item_doc.stock_uom != item.stock_uom:
@@ -115,6 +116,10 @@ def insert_item(doc, item):
 			)
 		item_doc.item_name = item.item_code  # also update the name and description of existing item
 		item_doc.description = item.description
+
+	if item.get("gst_hsn_code"):
+		item_doc.gst_hsn_code = item.get("gst_hsn_code")
+	item_doc.save(ignore_permissions=True)
 
 	make_item_price(item_doc.name, item.rate, doc.price_list)
 	frappe.db.set_value("Medication Linked Item", item.name, "item", item.item_code)

--- a/healthcare/healthcare/doctype/observation_template/observation_template.js
+++ b/healthcare/healthcare/doctype/observation_template/observation_template.js
@@ -2,6 +2,12 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Observation Template", {
+	setup: function (frm) {
+		if (frappe.meta.has_field(frm.doc.doctype, "gst_hsn_code")) {
+			frm.add_fetch("item", "gst_hsn_code", "gst_hsn_code");
+		}
+	},
+
 	onload: function(frm) {
 		set_select_field_options(frm);
 	},
@@ -48,19 +54,6 @@ frappe.ui.form.on("Observation Template", {
 	permitted_data_type: function(frm) {
 		set_observation_reference_range(frm);
 	},
-
-	observation_name: function(frm) {
-		frm.set_value("change_in_item", 1)
-	},
-
-	rate: function(frm) {
-		frm.set_value("change_in_item", 1)
-	},
-
-	item_group: function(frm) {
-		frm.set_value("change_in_item", 1)
-	},
-
 });
 
 frappe.ui.form.on("Observation Reference Range", {

--- a/healthcare/healthcare/doctype/observation_template/observation_template.py
+++ b/healthcare/healthcare/doctype/observation_template/observation_template.py
@@ -17,9 +17,17 @@ class ObservationTemplate(Document):
 			create_item_from_template(self)
 
 	def on_update(self):
-		# If change_in_item update Item and Price List
-		if self.change_in_item and self.is_billable:
+		doc_before_save = self.get_doc_before_save()
+		if not doc_before_save:
+			return
+		if (
+			doc_before_save.rate != self.rate
+			or doc_before_save.is_billable != self.is_billable
+			or doc_before_save.item_group != self.item_group
+			or doc_before_save.get("gst_hsn_code") != self.get("gst_hsn_code")
+		):
 			update_item_and_item_price(self)
+
 		if not self.item and self.is_billable:
 			create_item_from_template(self)
 

--- a/healthcare/healthcare/doctype/therapy_plan_template/therapy_plan_template.js
+++ b/healthcare/healthcare/doctype/therapy_plan_template/therapy_plan_template.js
@@ -2,6 +2,12 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Therapy Plan Template', {
+	setup: function (frm) {
+		if (frappe.meta.has_field(frm.doc.doctype, "gst_hsn_code")) {
+			frm.add_fetch("linked_item", "gst_hsn_code", "gst_hsn_code");
+		}
+	},
+
 	refresh: function(frm) {
 		frm.set_query('therapy_type', 'therapy_types', () => {
 			return {

--- a/healthcare/healthcare/doctype/therapy_plan_template/therapy_plan_template.py
+++ b/healthcare/healthcare/doctype/therapy_plan_template/therapy_plan_template.py
@@ -28,6 +28,7 @@ class TherapyPlanTemplate(Document):
 			doc_before_save.item_name != self.item_name
 			or doc_before_save.item_group != self.item_group
 			or doc_before_save.description != self.description
+			or doc_before_save.get("gst_hsn_code") != self.get("gst_hsn_code")
 		):
 			self.update_item()
 

--- a/healthcare/healthcare/doctype/therapy_type/therapy_type.js
+++ b/healthcare/healthcare/doctype/therapy_type/therapy_type.js
@@ -43,36 +43,8 @@ frappe.ui.form.on('Therapy Type', {
 			frm.set_value('item_code', frm.doc.therapy_type);
 		if (!frm.doc.description)
 			frm.set_value('description', frm.doc.therapy_type);
-		mark_change_in_item(frm);
 	},
-
-	rate: function(frm) {
-		mark_change_in_item(frm);
-	},
-
-	is_billable: function (frm) {
-		mark_change_in_item(frm);
-	},
-
-	item_group: function(frm) {
-		mark_change_in_item(frm);
-	},
-
-	description: function(frm) {
-		mark_change_in_item(frm);
-	},
-
-	medical_department: function(frm) {
-		mark_change_in_item(frm);
-	},
-
 });
-
-let mark_change_in_item = function(frm) {
-	if (!frm.doc.__islocal) {
-		frm.doc.change_in_item = 1;
-	}
-};
 
 let change_template_code = function(doc) {
 	let d = new frappe.ui.Dialog({

--- a/healthcare/healthcare/doctype/therapy_type/therapy_type.py
+++ b/healthcare/healthcare/doctype/therapy_type/therapy_type.py
@@ -24,7 +24,16 @@ class TherapyType(Document):
 		create_item_from_therapy(self)
 
 	def on_update(self):
-		if self.change_in_item:
+		doc_before_save = self.get_doc_before_save()
+		if not doc_before_save:
+			return
+		if (
+			doc_before_save.rate != self.rate
+			or doc_before_save.is_billable != self.is_billable
+			or doc_before_save.item_group != self.item_group
+			or doc_before_save.description != self.description
+			or doc_before_save.get("gst_hsn_code") != self.get("gst_hsn_code")
+		):
 			self.update_item_and_item_price()
 
 	def enable_disable_item(self):
@@ -57,8 +66,6 @@ class TherapyType(Document):
 
 		elif not self.is_billable and self.item:
 			frappe.db.set_value("Item", self.item, "disabled", 1)
-
-		self.db_set("change_in_item", 0)
 
 	@frappe.whitelist()
 	def add_exercises(self):


### PR DESCRIPTION
- The HSN/SAC code is updated in the linked Item when any of the Healthcare masters like `Clinical Procedure Template`, `Observation Template`, `Therapy Type`, `Therapy Plan Template`, `Healthcare Service Unit Type` and `Medication` are updated:

closes #142 