### PR TITLE
fix(Diagnostic Report): correct unexpected behavior in Diagnostic Report

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -169,9 +169,10 @@
    "read_only": 1
   }
  ],
+ "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-04 18:41:30.142285",
+ "modified": "2025-09-02 13:44:04.932831",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Diagnostic Report",
@@ -191,6 +192,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [

--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -328,6 +328,7 @@ def add_observation(**args):
 	if args.get("parent"):
 		observation_doc.parent_observation = args.get("parent")
 	observation_doc.sales_invoice_item = args.get("child") if args.get("child") else ""
+	observation_doc.service_request = args.get("service_request")
 	observation_doc.insert(ignore_permissions=True)
 	return observation_doc.name
 

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -346,12 +346,18 @@ def make_observation(service_request, appointment=None):
 			observation = create_observation(service_request, appointment)
 
 	diagnostic_report = frappe.db.exists(
-		"Diagnostic Report", {"reference_name": service_request.order_group}
+		"Diagnostic Report", {"docname": service_request.order_group}
 	)
 	if not diagnostic_report:
-		insert_diagnostic_report(service_request, sample_collection.name)
+		insert_diagnostic_report(service_request, sample_collection.name if sample_collection else None)
 
 	if sample_collection:
+		if diagnostic_report and not frappe.db.get_value(
+			"Diagnostic Report", diagnostic_report, "sample_collection"
+		):
+			frappe.db.set_value(
+				"Diagnostic Report", diagnostic_report, "sample_collection", sample_collection.name
+			)
 		return sample_collection.name, "Sample Collection"
 	elif observation:
 		return observation.name, "Observation"


### PR DESCRIPTION
- Fixed issue where Diagnostic Report did not fetch Observations created from Sample Collection (Patient Encounter).
- Fixed duplicate Diagnostic Report creation when generating Observations from Service Requests and link related sample collection.
- Prevented users from manually creating Diagnostic Reports.