### PR TITLE
fix(Observation): render result and interpretation from templates

### DIFF
--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -34,6 +34,7 @@ class Observation(Document):
 
 	def before_insert(self):
 		set_observation_idx(self)
+		self.render_templates()
 
 	def after_insert(self):
 		if self.appointment:
@@ -114,6 +115,19 @@ class Observation(Document):
 						frappe.bold(self.result_data), frappe.bold(self.permitted_data_type)
 					)
 				)
+
+	def render_templates(self):
+		if self.result_template and not self.result_text:
+			terms_and_conditions = frappe.get_doc("Terms and Conditions", self.result_template)
+
+			if terms_and_conditions.terms:
+				self.result_text = frappe.render_template(terms_and_conditions.terms, self.as_dict())
+
+		if self.interpretation_template and not self.result_interpretation:
+			terms_and_conditions = frappe.get_doc("Terms and Conditions", self.interpretation_template)
+
+			if terms_and_conditions.terms:
+				self.result_interpretation = frappe.render_template(terms_and_conditions.terms, self.as_dict())
 
 
 @frappe.whitelist()


### PR DESCRIPTION
- Ensures that when result_template or interpretation_template is set, corresponding template are render and fetched from Terms and Conditions.
- Automatically applies template rendering during the before_insert event.