### PR TITLE
fix(Patient Portal): prevent users without a linked patient from logging into the Patient Portal

### DIFF
--- a/healthcare/healthcare/api/patient_portal.py
+++ b/healthcare/healthcare/api/patient_portal.py
@@ -14,6 +14,11 @@ from healthcare.healthcare.utils import get_appointment_billing_item_and_rate
 
 @frappe.whitelist()
 def get_appointments():
+	patients = get_patients_with_relations()
+
+	if not len(patients):
+		return
+
 	appointment = frappe.qb.DocType("Patient Appointment")
 	encounter = frappe.qb.DocType("Patient Encounter")
 	practitioner = frappe.qb.DocType("Healthcare Practitioner")

--- a/healthcare/www/patient-portal/index.py
+++ b/healthcare/www/patient-portal/index.py
@@ -23,6 +23,14 @@ def get_context(context):
 	if portal_entry.role and not portal_entry.role in frappe.get_roles(frappe.session.user):
 		frappe.throw(_("Not permitted"), frappe.PermissionError)
 
+	if frappe.session.user != "Administrator" and not frappe.db.exists(
+		"Patient", {"status": "Active", "user_id": frappe.session.user}
+	):
+		frappe.throw(
+			_("You are not linked to any patient. Please contact the administration."),
+			frappe.PermissionError,
+		)
+
 	context.no_cache = 1
 	context.parents = [{"name": _("My Account"), "route": "/me"}]
 	context.body_class = "portal-page"


### PR DESCRIPTION
- Added validation to check if a user is associated with a Patient master.
- Restricted login to the Patient Portal when no linked patient is found.