### PR TITLE
fix: add missing field comment in Service Request and Medication Request

### DIFF
--- a/healthcare/healthcare/doctype/medication_request/medication_request.json
+++ b/healthcare/healthcare/doctype/medication_request/medication_request.json
@@ -54,6 +54,7 @@
   "dosage",
   "number_of_repeats_allowed",
   "column_break_91",
+  "comment",
   "order_description",
   "period",
   "occurrence_time",
@@ -458,12 +459,17 @@
    "label": "Medication Item",
    "options": "Item",
    "reqd": 1
+  },
+  {
+   "fieldname": "comment",
+   "fieldtype": "Small Text",
+   "label": "Comment"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-07 20:40:10.119600",
+ "modified": "2025-09-19 12:40:02.481435",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Medication Request",

--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.py
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.py
@@ -259,6 +259,7 @@ class PatientEncounter(Document):
 				"source_doc": "Patient Encounter",
 				"order_group": self.name,
 				"sequence": line_item.get("sequence"),
+				"patient_care_type": line_item.get("patient_care_type"),
 				"intent": line_item.get("intent"),
 				"priority": line_item.get("priority"),
 				"quantity": qty,
@@ -273,6 +274,7 @@ class PatientEncounter(Document):
 				"note": line_item.get("note"),
 				"patient_instruction": line_item.get("patient_instruction"),
 				"insurance_policy": self.insurance_policy,
+				"comment": line_item.get("comments") or line_item.get("lab_test_comment"),
 			}
 		)
 
@@ -290,7 +292,6 @@ class PatientEncounter(Document):
 			order.update(
 				{
 					"referred_to_practitioner": line_item.get("practitioner"),
-					"ordered_for": line_item.get("date"),
 				}
 			)
 
@@ -307,9 +308,6 @@ class PatientEncounter(Document):
 				{
 					"template_dt": template_doc.get("doctype"),
 					"template_dn": template_doc.get("name"),
-					# "patient_care_type": line_item.patient_care_type
-					# if line_item.patient_care_type
-					# else template_doc.get("patient_care_type"),
 				}
 			)
 

--- a/healthcare/healthcare/doctype/service_request/service_request.json
+++ b/healthcare/healthcare/doctype/service_request/service_request.json
@@ -57,6 +57,7 @@
   "interval",
   "healthcare_service_unit_type",
   "column_break_91",
+  "comment",
   "order_description",
   "patient_instructions",
   "medical_code_section",
@@ -601,6 +602,11 @@
    "fieldname": "practitioner_name",
    "fieldtype": "Data",
    "label": "Ordered by Practitioner Name"
+  },
+  {
+   "fieldname": "comment",
+   "fieldtype": "Small Text",
+   "label": "Comment"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -619,7 +625,7 @@
    "link_fieldname": "service_request"
   }
  ],
- "modified": "2025-07-18 20:36:56.162647",
+ "modified": "2025-09-19 12:52:31.151353",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Service Request",


### PR DESCRIPTION
- Added the missing comment field to Service Request and Medication Request, and mapped it from the corresponding fields in Patient Encounter child tables