### PR TITLE
feat(Practitioner Availability): enable availability for practitioners

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -870,7 +870,7 @@ let check_and_set_availability = function(frm) {
 			if (slot_info.slot_name == "Practitioner Availability") {
 				slot_html += `
 					<span>
-						<b>${__("General Availability")}</b>
+						<b>${ slot_info.display || slot_info.slot_name }</b>
 					</span><br>`;
 				if (slot_info.service_unit) {
 					slot_html += `<span><b>${__("Service Unit:")}</b> ${slot_info.service_unit}</span>`;

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -964,6 +964,7 @@ def build_availability_data(availability, appointment_type, date, practitioner_d
 	return (
 		{
 			"slot_name": "Practitioner Availability",
+			"display": availability_doc.display,
 			"service_unit": availability_doc.service_unit or None,
 			"avail_slot": available_slots,
 			"appointments": appointments,

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.js
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.js
@@ -28,5 +28,11 @@ frappe.ui.form.on("Practitioner Availability", {
 		if (frm.doc.type == "Available") {
 			frm.set_value("reason", "");
 		}
+	},
+
+	type: function (frm) {
+		if (frm.doc.type == "Available" && frm.doc.scope_type != "Healthcare Practitioner") {
+			frm.set_value("scope_type", "Healthcare Practitioner");
+		}
 	}
 });

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.json
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.json
@@ -11,16 +11,26 @@
   "scope_type",
   "scope",
   "amended_from",
+  "column_break_wewi",
+  "status",
+  "note",
+  "title",
+  "section_break_soiq",
   "column_break_gsyx",
   "start_date",
   "start_time",
   "end_time",
   "end_date",
   "duration",
-  "column_break_wewi",
-  "status",
-  "note",
-  "title"
+  "column_break_cena",
+  "repeat",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday"
  ],
  "fields": [
   {
@@ -160,13 +170,77 @@
    "label": "Title",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_soiq",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_cena",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Never",
+   "fieldname": "repeat",
+   "fieldtype": "Select",
+   "label": "Repeat",
+   "options": "Never\nDaily\nWeekly\nMonthly"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.repeat == \"Weekly\"",
+   "fieldname": "monday",
+   "fieldtype": "Check",
+   "label": "Monday "
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.repeat == \"Weekly\"",
+   "fieldname": "tuesday",
+   "fieldtype": "Check",
+   "label": "Tuesday"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.repeat == \"Weekly\"",
+   "fieldname": "wednesday",
+   "fieldtype": "Check",
+   "label": "Wednesday"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.repeat == \"Weekly\"",
+   "fieldname": "thursday",
+   "fieldtype": "Check",
+   "label": "Thursday"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.repeat == \"Weekly\"",
+   "fieldname": "friday",
+   "fieldtype": "Check",
+   "label": "Friday"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.repeat == \"Weekly\"",
+   "fieldname": "saturday",
+   "fieldtype": "Check",
+   "label": "Saturday"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.repeat == \"Weekly\"",
+   "fieldname": "sunday",
+   "fieldtype": "Check",
+   "label": "Sunday"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-03 12:36:20.299906",
+ "modified": "2025-09-09 16:42:54.253723",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Practitioner Availability",

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.json
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.json
@@ -14,6 +14,7 @@
   "amended_from",
   "column_break_wewi",
   "status",
+  "display",
   "note",
   "title",
   "section_break_soiq",
@@ -92,13 +93,13 @@
   },
   {
    "allow_in_quick_entry": 1,
-   "default": "Unavailable",
+   "default": "Available",
    "fieldname": "type",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Type",
-   "options": "\nUnavailable\nAvailable",
+   "options": "\nAvailable\nUnavailable",
    "reqd": 1
   },
   {
@@ -242,13 +243,20 @@
    "fieldtype": "Link",
    "label": "Service Unit",
    "options": "Healthcare Service Unit"
+  },
+  {
+   "depends_on": "eval: doc.type == \"Available\"",
+   "fieldname": "display",
+   "fieldtype": "Data",
+   "in_standard_filter": 1,
+   "label": "Display"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-24 18:17:00.186144",
+ "modified": "2025-09-25 16:57:37.516537",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Practitioner Availability",

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.json
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.json
@@ -10,6 +10,7 @@
   "reason",
   "scope_type",
   "scope",
+  "service_unit",
   "amended_from",
   "column_break_wewi",
   "status",
@@ -56,6 +57,7 @@
    "label": "Scope Type",
    "link_filters": "[[\"DocType\",\"name\",\"in\",[\"Healthcare Practitioner\",\"Healthcare Service Unit\",\"Medical Department\"]]]",
    "options": "DocType",
+   "read_only_depends_on": "eval: doc.type == \"Available\"",
    "reqd": 1,
    "search_index": 1
   },
@@ -97,7 +99,6 @@
    "in_standard_filter": 1,
    "label": "Type",
    "options": "\nUnavailable\nAvailable",
-   "read_only": 1,
    "reqd": 1
   },
   {
@@ -234,13 +235,20 @@
    "fieldname": "sunday",
    "fieldtype": "Check",
    "label": "Sunday"
+  },
+  {
+   "depends_on": "eval: doc.type == \"Available\" && doc.scope_type == \"Healthcare Practitioner\"",
+   "fieldname": "service_unit",
+   "fieldtype": "Link",
+   "label": "Service Unit",
+   "options": "Healthcare Service Unit"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-09 16:42:54.253723",
+ "modified": "2025-09-24 18:17:00.186144",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Practitioner Availability",

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.py
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.py
@@ -84,26 +84,33 @@ class PractitionerAvailability(Document):
 					continue
 				if has_time_overlap(r):
 					frappe.throw(
-						_(
-							f"Overlaps with another Available block: "
-							f"{get_link_to_form(self.doctype, r.get('name'))}"
-						)
+						_(f"Overlaps with another Availability: " f"{get_link_to_form(self.doctype, r.get('name'))}")
 					)
 		else:
-			has_overlap_with_available = False
-			for r in rows:
-				if r.get("type") != "Available":
-					continue
-				if has_time_overlap(r):
-					has_overlap_with_available = True
-					break
-			if not has_overlap_with_available:
-				frappe.throw(
-					_(
-						"Unavailable block must overlap at least partially with an existing "
-						"Available block for the same scope."
+			if self.scope_type == "Healthcare Practitioner":
+				has_overlap_with_available = False
+				for r in rows:
+					if r.get("type") != "Available":
+						continue
+					if has_time_overlap(r):
+						has_overlap_with_available = True
+						break
+				if not has_overlap_with_available:
+					frappe.throw(
+						_(
+							"Unavailable block for a practitioner must overlap at least partially with an existing Availability"
+						)
 					)
-				)
+			else:
+				for r in rows:
+					if r.get("type") == "Available":
+						continue
+					if has_time_overlap(r):
+						frappe.throw(
+							_(
+								f"Overlaps with another Unvailability: " f"{get_link_to_form(self.doctype, r.get('name'))}"
+							)
+						)
 
 	def validate_existing_appointments(self):
 		if self.type != "Unavailable":

--- a/healthcare/healthcare/doctype/practitioner_availability/test_practitioner_availability.py
+++ b/healthcare/healthcare/doctype/practitioner_availability/test_practitioner_availability.py
@@ -1,11 +1,15 @@
 # Copyright (c) 2025, earthians Health Informatics Pvt. Ltd. and Contributors
 # See license.txt
 
-from datetime import timedelta
-
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import nowdate
+
+from healthcare.healthcare.doctype.patient_appointment.test_patient_appointment import (
+	create_appointment,
+	create_patient,
+	create_practitioner,
+)
 
 
 class IntegrationTestPractitionerAvailability(IntegrationTestCase):
@@ -19,6 +23,9 @@ class IntegrationTestPractitionerAvailability(IntegrationTestCase):
 		frappe.db.sql("DELETE FROM `tabPatient Appointment`")
 
 		frappe.db.set_single_value("Healthcare Settings", "show_payment_popup", 0)
+		self.patient = create_patient()
+		self.practitioner = create_practitioner()
+		self.practitioner_1 = create_practitioner(id=1)
 
 	def create_practitioner_availability(
 		self,
@@ -27,7 +34,9 @@ class IntegrationTestPractitionerAvailability(IntegrationTestCase):
 		scope=None,
 		scope_type=None,
 		date=None,
+		end_date=None,
 		type="Available",
+		service_unit=None,
 	):
 		return frappe.get_doc(
 			{
@@ -35,55 +44,107 @@ class IntegrationTestPractitionerAvailability(IntegrationTestCase):
 				"type": type,
 				"start_date": date or "2025-01-01",
 				"start_time": start,
-				"end_date": date or "2025-01-01",
+				"end_date": end_date or "2025-01-01",
 				"end_time": end,
 				"scope_type": scope_type or "Healthcare Service Unit",
 				"scope": scope or "Service Unit-A",
 				"status": "Active",
+				"service_unit": service_unit,
 			}
 		).insert(ignore_permissions=True, ignore_links=True, ignore_if_duplicate=True)
 
-	def create_appointment(self, date, time, minutes=20, scope=None, status="Scheduled"):
-		return frappe.get_doc(
-			{
-				"doctype": "Patient Appointment",
-				"status": status,
-				"service_unit": scope or "Service Unit-A",
-				"appointment_date": date,
-				"appointment_time": time,
-				"duration": minutes,
-			}
-		).insert(
-			ignore_permissions=True,
-			ignore_links=True,
-			ignore_if_duplicate=True,
-			ignore_mandatory=True,
-		)
-
 	def test_duration(self):
-		pa = self.create_practitioner_availability("08:00:00", "08:30:00")
+		pa = self.create_practitioner_availability(
+			"08:00:00",
+			"08:30:00",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
 		self.assertEqual(pa.duration, 30)
 
 	def test_simple_overlap(self):
-		self.create_practitioner_availability("09:00:00", "10:00:00")
+		self.create_practitioner_availability(
+			"09:00:00",
+			"10:00:00",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
 		with self.assertRaises(frappe.ValidationError):
-			self.create_practitioner_availability("09:30:00", "10:30:00")
+			self.create_practitioner_availability(
+				"09:30:00",
+				"10:30:00",
+				scope_type="Healthcare Practitioner",
+				scope=self.practitioner,
+				service_unit="Service Unit-A",
+			)
 
 	def test_touching_overlap(self):
-		self.create_practitioner_availability("10:00:00", "11:00:00")
-		self.create_practitioner_availability("11:00:00", "12:00:00")
+		self.create_practitioner_availability(
+			"10:00:00",
+			"11:00:00",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		self.create_practitioner_availability(
+			"11:00:00",
+			"12:00:00",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
 
 	def test_no_overlap(self):
-		self.create_practitioner_availability("10:00:00", "11:00:00")
-		self.create_practitioner_availability("11:01:00", "12:00:00")
+		self.create_practitioner_availability(
+			"10:00:00",
+			"11:00:00",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		self.create_practitioner_availability(
+			"11:01:00",
+			"12:00:00",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
 
 	def test_different_scope_no_overlap(self):
-		self.create_practitioner_availability("14:00:00", "15:00:00", scope="Service Unit-A")
-		self.create_practitioner_availability("14:00:00", "15:00:00", scope="Service Unit-B")
+		self.create_practitioner_availability(
+			"14:00:00",
+			"15:00:00",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		self.create_practitioner_availability(
+			"14:00:00",
+			"15:00:00",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner_1,
+			service_unit="Service Unit-B",
+		)
 
 	def test_different_date_no_overlap(self):
-		self.create_practitioner_availability("16:00:00", "17:00:00", date="2025-01-03")
-		self.create_practitioner_availability("16:00:00", "17:00:00")
+		self.create_practitioner_availability(
+			"16:00:00",
+			"17:00:00",
+			date="2025-01-03",
+			end_date="2025-01-03",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		self.create_practitioner_availability(
+			"16:00:00",
+			"17:00:00",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
 
 	# def test_unavailable_without_available_block_is_not_allowed(self):
 	# 	# Unavailable should not be allowed if no overlap with Available
@@ -93,63 +154,369 @@ class IntegrationTestPractitionerAvailability(IntegrationTestCase):
 	# 		)
 
 	def test_unavailable_partial_overlap_with_available_allowed(self):
-		self.create_practitioner_availability("10:00:00", "11:00:00", date="2025-01-06")
 		self.create_practitioner_availability(
-			"10:50:00", "11:30:00", date="2025-01-06", type="Unavailable"
+			"10:00:00",
+			"11:00:00",
+			date="2025-01-06",
+			end_date="2025-01-06",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		self.create_practitioner_availability(
+			"10:50:00",
+			"11:30:00",
+			date="2025-01-06",
+			end_date="2025-01-06",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			type="Unavailable",
 		)
 
 	def test_appointment_inside_block_conflicts(self):
 		d = nowdate()
-		self.create_practitioner_availability("09:00:00", "12:00:00", date=d)
-		self.create_appointment(date=d, time="11:30:00", minutes=20)
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date=d,
+			end_date=d,
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		create_appointment(
+			self.patient,
+			self.practitioner,
+			service_unit="Service Unit-A",
+			appointment_date=d,
+			appointment_time="11:30:00",
+			duration=20,
+		)
 		with self.assertRaises(frappe.ValidationError):
-			self.create_practitioner_availability("11:00:00", "12:00:00", date=d, type="Unavailable")
+			self.create_practitioner_availability(
+				"11:00:00",
+				"12:00:00",
+				date=d,
+				end_date=d,
+				scope_type="Healthcare Practitioner",
+				scope=self.practitioner,
+				type="Unavailable",
+			)
 
 	def test_block_inside_appointment_conflicts(self):
 		d = nowdate()
-		self.create_practitioner_availability("09:00:00", "12:00:00", date=d)
-		self.create_appointment(date=d, time="10:00:00", minutes=120)
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date=d,
+			end_date=d,
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		create_appointment(
+			self.patient,
+			self.practitioner,
+			service_unit="Service Unit-A",
+			appointment_date=d,
+			appointment_time="10:00:00",
+			duration=120,
+		)
 		with self.assertRaises(frappe.ValidationError):
-			self.create_practitioner_availability("10:30:00", "11:30:00", date=d, type="Unavailable")
+			self.create_practitioner_availability(
+				"10:30:00",
+				"11:30:00",
+				date=d,
+				end_date=d,
+				scope_type="Healthcare Practitioner",
+				scope=self.practitioner,
+				type="Unavailable",
+			)
 
 	def test_partial_overlap_appointment_start_conflicts(self):
 		d = nowdate()
-		self.create_practitioner_availability("09:00:00", "12:00:00", date=d)
-		self.create_appointment(date=d, time="09:50:00", minutes=20)
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date=d,
+			end_date=d,
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		create_appointment(
+			self.patient,
+			self.practitioner,
+			service_unit="Service Unit-A",
+			appointment_date=d,
+			appointment_time="09:50:00",
+			duration=20,
+		)
 		with self.assertRaises(frappe.ValidationError):
-			self.create_practitioner_availability("10:00:00", "10:30:00", date=d, type="Unavailable")
+			self.create_practitioner_availability(
+				"10:00:00",
+				"10:30:00",
+				date=d,
+				end_date=d,
+				scope_type="Healthcare Practitioner",
+				scope=self.practitioner,
+				type="Unavailable",
+			)
 
 	def test_partial_overlap_appointment_end_conflicts(self):
 		d = nowdate()
-		self.create_practitioner_availability("09:00:00", "12:00:00", date=d)
-		self.create_appointment(date=d, time="10:20:00", minutes=30)
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date=d,
+			end_date=d,
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		create_appointment(
+			self.patient,
+			self.practitioner,
+			service_unit="Service Unit-A",
+			appointment_date=d,
+			appointment_time="10:20:00",
+			duration=30,
+		)
 		with self.assertRaises(frappe.ValidationError):
-			self.create_practitioner_availability("10:00:00", "10:30:00", date=d, type="Unavailable")
+			self.create_practitioner_availability(
+				"10:00:00", "10:30:00", date=d, end_date=d, type="Unavailable"
+			)
 
 	def test_appointment_back_to_back_is_allowed(self):
 		d = nowdate()
-		self.create_practitioner_availability("09:00:00", "12:00:00", date=d)
-		self.create_appointment(date=d, time="10:00:00", minutes=30)
-		self.create_practitioner_availability("10:30:00", "11:00:00", date=d, type="Unavailable")
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date=d,
+			end_date=d,
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		create_appointment(
+			self.patient,
+			self.practitioner,
+			service_unit="Service Unit-A",
+			appointment_date=d,
+			appointment_time="10:00:00",
+			duration=30,
+		)
+		self.create_practitioner_availability(
+			"10:30:00",
+			"11:00:00",
+			date=d,
+			end_date=d,
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			type="Unavailable",
+		)
 
 	def test_appointment_gap_is_allowed(self):
 		d = nowdate()
-		self.create_practitioner_availability("09:00:00", "12:00:00", date=d)
-		self.create_appointment(date=d, time="10:00:00", minutes=30)
-		self.create_practitioner_availability("10:31:00", "11:00:00", date=d, type="Unavailable")
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date=d,
+			end_date=d,
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		create_appointment(
+			self.patient,
+			self.practitioner,
+			service_unit="Service Unit-A",
+			appointment_date=d,
+			appointment_time="10:00:00",
+			duration=30,
+		)
+		self.create_practitioner_availability(
+			"10:31:00",
+			"11:00:00",
+			date=d,
+			end_date=d,
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			type="Unavailable",
+		)
 
 	def test_appointment_different_scope_is_allowed(self):
 		d = nowdate()
-		self.create_practitioner_availability("14:00:00", "15:00:00", date=d, scope="Service Unit-A")
-		self.create_practitioner_availability("14:00:00", "15:00:00", date=d, scope="Service Unit-B")
-		self.create_appointment(date=d, time="14:00:00", minutes=30, scope="Service Unit-A")
 		self.create_practitioner_availability(
-			"14:00:00", "14:30:00", date=d, scope="Service Unit-B", type="Unavailable"
+			"14:00:00", "15:00:00", date=d, end_date=d, scope="Service Unit-A"
+		)
+		self.create_practitioner_availability(
+			"14:00:00", "15:00:00", date=d, end_date=d, scope="Service Unit-B"
+		)
+		create_appointment(
+			self.patient,
+			self.practitioner,
+			service_unit="Service Unit-A",
+			appointment_date=d,
+			appointment_time="14:00:00",
+			duration=30,
+		)
+		self.create_practitioner_availability(
+			"14:00:00", "14:30:00", date=d, end_date=d, scope="Service Unit-B", type="Unavailable"
 		)
 
 	def test_appointment_cancelled_appointments_are_ignored(self):
 		d = nowdate()
-		self.create_practitioner_availability("09:00:00", "12:00:00", date=d)
-		appointment = self.create_appointment(date=d, time="11:30:00", minutes=30)
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date=d,
+			end_date=d,
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		appointment = create_appointment(
+			self.patient,
+			self.practitioner,
+			service_unit="Service Unit-A",
+			appointment_date=d,
+			appointment_time="11:30:00",
+			duration=30,
+		)
 		frappe.db.set_value("Patient Appointment", appointment.name, "status", "Cancelled")
-		self.create_practitioner_availability("11:00:00", "12:00:00", date=d, type="Unavailable")
+		self.create_practitioner_availability(
+			"11:00:00",
+			"12:00:00",
+			date=d,
+			end_date=d,
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			type="Unavailable",
+		)
+
+	def test_available_partial_overlap_with_available_conflicts(self):
+		self.create_practitioner_availability(
+			"10:00:00",
+			"11:00:00",
+			date="2025-01-06",
+			end_date="2025-01-08",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		with self.assertRaises(frappe.ValidationError):
+			self.create_practitioner_availability(
+				"10:30:00",
+				"11:30:00",
+				date="2025-01-07",
+				end_date="2025-01-09",
+				scope_type="Healthcare Practitioner",
+				scope=self.practitioner,
+				service_unit="Service Unit-A",
+			)
+
+	def test_available_inside_existing_available_conflicts(self):
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date="2025-01-06",
+			end_date="2025-01-08",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		with self.assertRaises(frappe.ValidationError):
+			self.create_practitioner_availability(
+				"10:00:00",
+				"11:00:00",
+				date="2025-01-07",
+				end_date="2025-01-07",
+				scope_type="Healthcare Practitioner",
+				scope=self.practitioner,
+				service_unit="Service Unit-A",
+			)
+
+	def test_existing_available_inside_new_available_conflicts(self):
+		self.create_practitioner_availability(
+			"10:00:00",
+			"11:00:00",
+			date="2025-01-07",
+			end_date="2025-01-07",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		with self.assertRaises(frappe.ValidationError):
+			self.create_practitioner_availability(
+				"09:00:00",
+				"12:00:00",
+				date="2025-01-06",
+				end_date="2025-01-08",
+				scope_type="Healthcare Practitioner",
+				scope=self.practitioner,
+				service_unit="Service Unit-A",
+			)
+
+	def test_partial_overlap_start_conflicts_available(self):
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date="2025-01-06",
+			end_date="2025-01-08",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		with self.assertRaises(frappe.ValidationError):
+			self.create_practitioner_availability(
+				"08:30:00",
+				"09:30:00",
+				date="2025-01-07",
+				end_date="2025-01-07",
+				scope_type="Healthcare Practitioner",
+				scope=self.practitioner,
+				service_unit="Service Unit-A",
+			)
+
+	def test_partial_overlap_end_conflicts_available(self):
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date="2025-01-06",
+			end_date="2025-01-08",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		with self.assertRaises(frappe.ValidationError):
+			self.create_practitioner_availability(
+				"11:30:00",
+				"12:30:00",
+				date="2025-01-07",
+				end_date="2025-01-07",
+				scope_type="Healthcare Practitioner",
+				scope=self.practitioner,
+				service_unit="Service Unit-A",
+			)
+
+	def test_back_to_back_available_is_allowed(self):
+		self.create_practitioner_availability(
+			"09:00:00",
+			"12:00:00",
+			date="2025-01-06",
+			end_date="2025-01-06",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)
+		# Back-to-back on same day
+		self.create_practitioner_availability(
+			"12:00:00",
+			"13:00:00",
+			date="2025-01-06",
+			end_date="2025-01-06",
+			scope_type="Healthcare Practitioner",
+			scope=self.practitioner,
+			service_unit="Service Unit-A",
+		)


### PR DESCRIPTION
[docs](https://marley.frappe.cloud/wiki/practitioner-availability)

- You can create availability for practitioners in the `Practitioner Availability` doctype.
- A service unit can be assigned to indicate where the practitioner will be available.
- When booking an appointment, available slots from Practitioner Availability are displayed alongside the Practitioner Schedule.
- The system prevents booking appointments during unavailable slots.

<img width="1913" height="787" alt="Screenshot from 2025-09-26 14-23-05" src="https://github.com/user-attachments/assets/e01faae5-b5bf-4c63-afa0-57b699c205b4" />

<img width="1913" height="787" alt="Screenshot from 2025-09-26 14-21-28" src="https://github.com/user-attachments/assets/63e57419-b646-435e-9a25-15f1e6ccf144" />

