### PR TITLE
fix: No module named 'erpnext'

### DIFF
--- a/healthcare/hooks.py
+++ b/healthcare/hooks.py
@@ -8,7 +8,7 @@ app_icon = "octicon octicon-file-directory"
 app_color = "grey"
 app_email = "info@earthianslive.com"
 app_license = "GNU GPL V3"
-required_apps = ["erpnext"]
+required_apps = ["frappe/erpnext"]
 
 # Includes in <head>
 # ------------------


### PR DESCRIPTION
Fixes : #731 
Could not find app "erpnext" on new bench setup.

It's throwing this error while installing on new bench without explicitly get-app erpnext

Solution Description
changed erpnext to frappe/erpnext , So that on installing it will check the dependency and get it cloned and installed.