### PR TITLE
fix: Unique requirement on system_uri in Code Value Set

### DIFF
--- a/healthcare/healthcare/doctype/code_value_set/code_value_set.json
+++ b/healthcare/healthcare/doctype/code_value_set/code_value_set.json
@@ -51,8 +51,7 @@
    "fetch_from": "code_system.uri",
    "fieldname": "system_uri",
    "fieldtype": "Data",
-   "label": "System URI",
-   "unique": 1
+   "label": "System URI"
   }
  ],
  "index_web_pages_for_search": 1,


### PR DESCRIPTION
The unique requirement on the field "system_uri" in "Code Value Set" appears to be restrictive. This does not allow for more than one Code Value Set per Code System. And Code Value Set is a useful tool to implement sub-categories.
Possible Code Value Sets are Musculoskeletal , Cardiovascular etc. Closes #813