### PR TITLE
fix(Patient): add configurable registration item and improve patient registration invoicing

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.js
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.js
@@ -56,6 +56,7 @@ frappe.ui.form.on('Healthcare Settings', {
 		set_query_service_item(frm, 'inpatient_visit_charge_item');
 		set_query_service_item(frm, 'op_consulting_charge_item');
 		set_query_service_item(frm, 'clinical_procedure_consumable_item');
+		set_query_service_item(frm, 'registration_item');
 
 		frappe.call({
 			method: "healthcare.healthcare.doctype.healthcare_settings.healthcare_settings.check_payments_app",

--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
@@ -14,6 +14,7 @@
   "default_google_calendar",
   "column_break_9",
   "collect_registration_fee",
+  "registration_item",
   "registration_fee",
   "show_payment_popup",
   "enable_free_follow_ups",
@@ -500,11 +501,19 @@
    "fieldtype": "Link",
    "label": "Mode of Payment",
    "options": "Mode of Payment"
+  },
+  {
+   "depends_on": "eval:doc.collect_registration_fee == 1",
+   "fieldname": "registration_item",
+   "fieldtype": "Link",
+   "label": "Registration Item",
+   "mandatory_depends_on": "eval:doc.collect_registration_fee == 1",
+   "options": "Item"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2025-09-17 15:20:01.438478",
+ "modified": "2025-11-05 15:45:05.268654",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Healthcare Settings",

--- a/healthcare/healthcare/doctype/patient/patient.js
+++ b/healthcare/healthcare/doctype/patient/patient.js
@@ -136,10 +136,10 @@ let invoice_registration = function (frm) {
 		method: 'invoice_patient_registration',
 		callback: function(data) {
 			if (!data.exc) {
-				if (data.message.invoice) {
-					frappe.set_route('Form', 'Sales Invoice', data.message.invoice);
+				if (data.message) {
+					var doc = frappe.model.sync(data.message);
+					frappe.set_route("Form", doc[0].doctype, doc[0].name);
 				}
-				cur_frm.reload_doc();
 			}
 		}
 	});

--- a/healthcare/healthcare/doctype/patient/patient.py
+++ b/healthcare/healthcare/doctype/patient/patient.py
@@ -184,17 +184,36 @@ class Patient(Document):
 
 	@frappe.whitelist()
 	def invoice_patient_registration(self):
-		if frappe.db.get_single_value("Healthcare Settings", "registration_fee"):
-			company = frappe.defaults.get_user_default("company")
-			if not company:
-				company = frappe.db.get_single_value("Global Defaults", "default_company")
+		registration_fee = frappe.db.get_single_value("Healthcare Settings", "registration_fee")
+		if not registration_fee:
+			return
 
-			sales_invoice = make_invoice(self.name, company)
-			sales_invoice.save(ignore_permissions=True)
-			frappe.db.set_value("Patient", self.name, "status", "Active")
-			send_registration_sms(self)
+		# Check if registration invoice already exists
+		existing_item = frappe.db.exists(
+			"Sales Invoice Item",
+			{
+				"reference_dt": "Patient",
+				"reference_dn": self.name,
+				"item_name": "Registration Fee",
+				"docstatus": 0,
+			},
+		)
 
-			return {"invoice": sales_invoice.name}
+		if existing_item:
+			invoice_name = frappe.db.get_value("Sales Invoice Item", existing_item, "parent")
+			sales_invoice = frappe.get_doc("Sales Invoice", invoice_name)
+			return sales_invoice.as_dict()
+
+		company = frappe.defaults.get_user_default("company") or frappe.db.get_single_value(
+			"Global Defaults", "default_company"
+		)
+
+		sales_invoice = make_invoice(self.name, company)
+		sales_invoice.insert(ignore_permissions=True)
+
+		send_registration_sms(self)
+
+		return sales_invoice.as_dict()
 
 	def set_contact(self):
 		contact = get_default_contact(self.doctype, self.name)
@@ -325,6 +344,7 @@ def create_customer(doc):
 
 def make_invoice(patient, company):
 	uom = frappe.db.exists("UOM", "Nos") or frappe.db.get_single_value("Stock Settings", "stock_uom")
+	registration_item = frappe.db.get_single_value("Healthcare Settings", "registration_item") or None
 	sales_invoice = frappe.new_doc("Sales Invoice")
 	sales_invoice.customer = frappe.db.get_value("Patient", patient, "customer")
 	sales_invoice.patient = patient
@@ -333,15 +353,24 @@ def make_invoice(patient, company):
 	sales_invoice.is_pos = 0
 	sales_invoice.debit_to = get_receivable_account(company)
 
-	item_line = sales_invoice.append("items")
-	item_line.item_name = "Registration Fee"
-	item_line.description = "Registration Fee"
-	item_line.qty = 1
-	item_line.uom = uom
-	item_line.conversion_factor = 1
-	item_line.income_account = get_income_account(None, company)
-	item_line.rate = frappe.db.get_single_value("Healthcare Settings", "registration_fee")
-	item_line.amount = item_line.rate
+	sales_invoice.append(
+		"items",
+		{
+			"item_code": registration_item or None,
+			"item_name": "Registration Fee",
+			"description": "Registration Fee",
+			"qty": 1,
+			"uom": uom or "Nos",
+			"stock_uom": uom or "Nos",
+			"rate": frappe.db.get_single_value("Healthcare Settings", "registration_fee"),
+			"price_list_rate": frappe.db.get_single_value("Healthcare Settings", "registration_fee"),
+			"income_account": get_income_account(None, company),
+			"conversion_factor": 1,
+			"reference_dt": "Patient",
+			"reference_dn": patient,
+		},
+	)
+
 	sales_invoice.set_missing_values()
 	return sales_invoice
 

--- a/healthcare/healthcare/doctype/patient/test_patient.py
+++ b/healthcare/healthcare/doctype/patient/test_patient.py
@@ -22,8 +22,10 @@ class TestPatient(IntegrationTestCase):
 
 	def test_patient_registration(self):
 		frappe.db.sql("""delete from `tabPatient`""")
+		registration_item = create_registration_item()
 		settings = frappe.get_single("Healthcare Settings")
 		settings.collect_registration_fee = 1
+		settings.registration_item = registration_item
 		settings.registration_fee = 500
 		settings.save()
 
@@ -33,7 +35,12 @@ class TestPatient(IntegrationTestCase):
 
 		# check sales invoice and patient status
 		result = patient.invoice_patient_registration()
-		self.assertTrue(frappe.db.exists("Sales Invoice", result.get("invoice")))
+		self.assertTrue(frappe.db.exists("Sales Invoice", result.get("name")))
+
+		invoice_doc = frappe.get_doc("Sales Invoice", result.get("name"))
+		self.assertTrue(invoice_doc.status, "Draft")
+
+		invoice_doc.submit()
 		self.assertTrue(patient.status, "Active")
 
 		settings.collect_registration_fee = 0
@@ -131,3 +138,19 @@ class TestPatient(IntegrationTestCase):
 
 		self.assertEqual(p1_customer_name, p2_customer_name)
 		self.assertEqual(p2_customer.customer_name, "John Doe")
+
+
+def create_registration_item():
+	if not frappe.db.exists("Item", "Registration Item"):
+		item = frappe.new_doc("Item")
+		item.item_code = "Registration Item"
+		item.item_name = "Registration Item"
+		item.description = "Registration Item"
+		item.item_group = "Services"
+		item.stock_uom = "Nos"
+		item.is_stock_item = 0
+		item.save()
+	else:
+		item = frappe.get_doc("Item", "Registration Item")
+
+	return item.name

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -930,6 +930,20 @@ def manage_invoice_submit_cancel(doc, method):
 				if item.reference_dt == "Patient Appointment":
 					manage_fee_validity(frappe.get_doc("Patient Appointment", item.reference_dn))
 
+				# set patient as active if registration invoice
+				if item.get("reference_dt") == "Patient":
+					registration_item = (
+						frappe.db.get_single_value("Healthcare Settings", "registration_item") or None
+					)
+					if registration_item:
+						is_registration = item.item_code == registration_item
+					else:
+						is_registration = item.item_name == "Registration Fee"
+
+					if is_registration:
+						status = "Active" if method == "on_submit" else "Disabled"
+						frappe.db.set_value("Patient", item.reference_dn, "status", status)
+
 		if method == "on_submit" and frappe.db.get_single_value(
 			"Healthcare Settings", "create_observation_on_si_submit"
 		):
@@ -1065,7 +1079,7 @@ def set_invoiced(item, method, ref_invoice=None):
 		else:
 			frappe.db.set_value(item.reference_dt, item.reference_dn, "invoiced", invoiced)
 	else:
-		if item.reference_dt not in ["Service Request", "Medication Request"]:
+		if item.reference_dt not in ["Service Request", "Medication Request", "Patient"]:
 			frappe.db.set_value(item.reference_dt, item.reference_dn, "invoiced", invoiced)
 
 	if item.reference_dt == "Patient Appointment":
@@ -1104,6 +1118,7 @@ def set_invoiced(item, method, ref_invoice=None):
 
 
 def validate_invoiced_on_submit(item):
+	is_invoiced = False
 	if (
 		item.reference_dt == "Clinical Procedure"
 		and frappe.db.get_single_value("Healthcare Settings", "clinical_procedure_consumable_item")
@@ -1114,6 +1129,18 @@ def validate_invoiced_on_submit(item):
 	elif item.reference_dt in ["Service Request", "Medication Request"]:
 		billing_status = frappe.db.get_value(item.reference_dt, item.reference_dn, "billing_status")
 		is_invoiced = True if billing_status == "Invoiced" else False
+
+	elif item.reference_dt == "Patient":
+		if frappe.db.get_single_value("Healthcare Settings", "collect_registration_fee"):
+			is_invoiced = frappe.db.exists(
+				"Sales Invoice Item",
+				{
+					"name": ["!=", item.name],
+					"reference_dn": item.reference_dn,
+					"item_name": "Registration Fee",
+					"docstatus": 1,
+				},
+			)
 
 	else:
 		is_invoiced = frappe.db.get_value(item.reference_dt, item.reference_dn, "invoiced")

--- a/healthcare/public/js/sales_invoice.js
+++ b/healthcare/public/js/sales_invoice.js
@@ -47,7 +47,7 @@ frappe.ui.form.on('Sales Invoice', {
 	},
 
 	onload_post_render(frm) {
-		if (frm.doc.items && frm.doc.items.length === 1 && !frm.doc.items[0].item_code) {
+		if (frm.doc.items && frm.doc.items.length === 1 && !frm.doc.items[0].item_name) {
 			frm.clear_table('items');
 			frm.refresh_field('items');  // Ensure UI updates
 		}


### PR DESCRIPTION
Closes #819 

- Added a setting in Healthcare Settings to choose which item should be used for the registration fee.
- Fixed an issue where invoices containing the registration item were getting cleared unintentionally.