### PR TITLE
fix(Healthcare Practitioner): remove invalid space character in Patient Encounter link_fieldname

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_practitioner/healthcare_practitioner.json
+++ b/healthcare/healthcare/doctype/healthcare_practitioner/healthcare_practitioner.json
@@ -397,7 +397,7 @@
  ],
  "grid_page_length": 50,
  "image_field": "image",
-  "links": [
+ "links": [
   {
    "group": "Consultations",
    "link_doctype": "Patient Appointment",
@@ -406,7 +406,7 @@
   {
    "group": "Consultations",
    "link_doctype": "Patient Encounter",
-   "link_fieldname": "practitioner "
+   "link_fieldname": "practitioner"
   },
   {
    "group": "Orders",
@@ -429,7 +429,7 @@
    "link_fieldname": "practitioner"
   }
  ],
- "modified": "2025-09-25 14:20:06.299954",
+ "modified": "2025-11-26 19:14:01.575157",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Healthcare Practitioner",


### PR DESCRIPTION
- remove trailing space in Patient Encounter link_fieldname from Healthcare Practitioner links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a linking issue in the Healthcare Practitioner module that affected Patient Encounter associations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->