### PR TITLE
fix: prevent selecting past dates in service request dialog

### DIFF
--- a/healthcare/public/js/healthcare_note.js
+++ b/healthcare/public/js/healthcare_note.js
@@ -292,12 +292,12 @@ healthcare.Orders = class Orders {
 						"depends_on": "eval:['Lab Test Template', 'Clinical Procedure Template'].includes(doc.order_template_type);",
 					},
 					// therapy
-					   {
+					{
 						"fieldname": "no_of_sessions",
 						"fieldtype": "Int",
 						"label": "No of Sessions",
 						"depends_on": "eval:doc.order_template_type=='Therapy Type';",
-					   },
+					},
 				],
 				primary_action: function() {
 					var data = d.get_values();
@@ -320,6 +320,13 @@ healthcare.Orders = class Orders {
 				primary_action_label: __("Create")
 			});
 			d.show();
+
+			const dateField = d.fields_dict?.date;
+			if (dateField?.datepicker) {
+				const today = new Date();
+				today.setHours(0, 0, 0, 0);
+				dateField.datepicker.update({ minDate: today });
+			}
 		};
 		$(".new-service-request-btn").click(_create_service_request);
 	}


### PR DESCRIPTION
- Prevent selecting past dates in the Clinical Procedure service request datepicker

<img width="1570" height="778" alt="Screenshot from 2025-12-12 17-21-15" src="https://github.com/user-attachments/assets/4b1d046d-bf7a-41ee-ba4d-5f48349af7eb" />

