### PR TITLE
Updating medication naming

### DIFF
--- a/healthcare/healthcare/doctype/medication/medication.json
+++ b/healthcare/healthcare/doctype/medication/medication.json
@@ -46,7 +46,8 @@
   {
    "fieldname": "generic_name",
    "fieldtype": "Data",
-   "label": "Generic Name"
+   "label": "Generic Name",
+   "reqd": 1
   },
   {
    "fieldname": "medication_class",
@@ -217,11 +218,11 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-12-25 09:36:30.992082",
+ "modified": "2025-12-31 17:13:12.796752",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Medication",
- "naming_rule": "By fieldname",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {

--- a/healthcare/healthcare/doctype/medication/medication.json
+++ b/healthcare/healthcare/doctype/medication/medication.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:generic_name",
+ "autoname": "format:{dosage_form}. {generic_name} {strength}{strength_uom}",
  "creation": "2020-03-24 15:56:36.583587",
  "doctype": "DocType",
  "editable_grid": 1,

--- a/healthcare/healthcare/doctype/medication/medication.json
+++ b/healthcare/healthcare/doctype/medication/medication.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:{dosage_form}. {generic_name} {strength}{strength_uom}",
+ "autoname": "format:{dosage_form} {generic_name} {strength}{strength_uom}",
  "creation": "2020-03-24 15:56:36.583587",
  "doctype": "DocType",
  "editable_grid": 1,

--- a/healthcare/healthcare/doctype/medication/medication.json
+++ b/healthcare/healthcare/doctype/medication/medication.json
@@ -46,9 +46,7 @@
   {
    "fieldname": "generic_name",
    "fieldtype": "Data",
-   "label": "Generic Name",
-   "no_copy": 1,
-   "unique": 1
+   "label": "Generic Name"
   },
   {
    "fieldname": "medication_class",
@@ -146,7 +144,8 @@
    "fieldname": "dosage_form",
    "fieldtype": "Link",
    "label": "Dosage Form",
-   "options": "Dosage Form"
+   "options": "Dosage Form",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_16",

--- a/healthcare/healthcare/doctype/medication/test_medication.py
+++ b/healthcare/healthcare/doctype/medication/test_medication.py
@@ -40,6 +40,10 @@ def create_medication(medication, is_billable=False, price_list=None):
 	medication_doc.strength = 500
 	medication_doc.strength_uom = "Milligram"
 	medication_doc.price_list = price_list
+
+	if not frappe.db.exists("Dosage Form", "Tablet"):
+		frappe.get_doc({"doctype": "Dosage Form", "dosage_form": "Tablet"}).insert()
+	medication_doc.dosage_form = "Tablet"
 	medication_doc.append(
 		"linked_items",
 		{"item_code": medication, "item_group": "Drug", "is_billable": is_billable, "rate": 25},

--- a/healthcare/healthcare/doctype/medication_request/test_medication_request.py
+++ b/healthcare/healthcare/doctype/medication_request/test_medication_request.py
@@ -18,7 +18,7 @@ from healthcare.healthcare.doctype.service_request.test_service_request import (
 
 class TestMedicationRequest(IntegrationTestCase):
 	def setup(self):
-		frappe.db.sql("""delete from `tabMedication` where name = '_Test Medication'""")
+		frappe.db.sql("""delete from `tabMedication` where name = 'Capsule _Test Medication 500Unit'""")
 
 	def test_medication_request(self):
 		patient, practitioner = create_healthcare_docs()
@@ -72,7 +72,7 @@ class TestMedicationRequest(IntegrationTestCase):
 
 
 def create_medication():
-	if not frappe.db.exists("Medication", "_Test Medication"):
+	if not frappe.db.exists("Medication", "Capsule _Test Medication 500Unit"):
 		if not frappe.db.exists("Medication Class", "Tablet"):
 			try:
 				medication = frappe.get_doc(
@@ -108,4 +108,4 @@ def create_medication():
 		except frappe.DuplicateEntryError:
 			pass
 	else:
-		return frappe.get_doc("Medication", "_Test Medication")
+		return frappe.get_doc("Medication", "Capsule _Test Medication 500Unit")


### PR DESCRIPTION
This update changes the naming convention for the Medication DocType to improve consistency and identification.

Medications will now be automatically named using the format: {dosage_form} {generic_name} {strength}{strength_uom}

Example: Tablet Paracetamol 500mg