### PR TITLE
refactor: centralize js include and fix patient age calculation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
                 .*node_modules.*|
                 healthcare/healthcare/doctype/patient/patient.js|
                 healthcare/healthcare/doctype/medication_request/medication_request.js|
+                healthcare/healthcare/doctype/service_request/service_request.js|
             )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/healthcare/controllers/service_request_controller.py
+++ b/healthcare/controllers/service_request_controller.py
@@ -3,7 +3,7 @@ import dateutil
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import getdate
+from frappe.utils import getdate, month_diff
 
 
 class ServiceRequestController(Document):
@@ -49,7 +49,8 @@ class ServiceRequestController(Document):
 	def set_patient_age(self):
 		patient = frappe.get_doc("Patient", self.patient)
 		self.patient_age_data = patient.get_age()
-		self.patient_age = dateutil.relativedelta.relativedelta(getdate(), getdate(patient.dob))
+		if patient.dob:
+			self.patient_age = int(month_diff(getdate(), getdate(patient.dob)) / 12)
 
 	def set_medication_qty(self):
 		if not self.doctype == "Medication Request":

--- a/healthcare/healthcare/doctype/medication_request/medication_request.js
+++ b/healthcare/healthcare/doctype/medication_request/medication_request.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, healthcare and contributors
 // For license information, please see license.txt
-{% include "healthcare/public/js/service_request.js" %}
+{% include "healthcare/healthcare/service_request.js" %}
 
 frappe.ui.form.on('Medication Request', {
     refresh: function(frm) {

--- a/healthcare/healthcare/doctype/service_request/service_request.js
+++ b/healthcare/healthcare/doctype/service_request/service_request.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, earthians and contributors
 // For license information, please see license.txt
-// {% include "healthcare/public/js/service_request.js" %}
+
+{% include "healthcare/healthcare/service_request.js" %}
 
 frappe.ui.form.on("Service Request", {
 	refresh: function (frm) {
@@ -39,15 +40,6 @@ frappe.ui.form.on("Service Request", {
 				d.show();
 			});
 		}
-		frm.set_query("order_group", function () {
-			return {
-				filters: {
-					docstatus: 1,
-					patient: frm.doc.patient,
-					practitioner: frm.doc.ordered_by,
-				},
-			};
-		});
 
 		frm.set_query("template_dt", function () {
 			let order_template_doctypes = [
@@ -69,22 +61,6 @@ frappe.ui.form.on("Service Request", {
 			return {
 				filters: {
 					code_system: "Request Status",
-				},
-			};
-		});
-
-		frm.set_query("patient", function () {
-			return {
-				filters: {
-					status: "Active",
-				},
-			};
-		});
-
-		frm.set_query("staff_role", function () {
-			return {
-				filters: {
-					restrict_to_domain: "Healthcare",
 				},
 			};
 		});

--- a/healthcare/healthcare/service_request.js
+++ b/healthcare/healthcare/service_request.js
@@ -12,7 +12,7 @@ frappe.ui.form.on(cur_frm.doctype, {
 				filters: {
 					docstatus: 1,
 					patient: frm.doc.patient,
-					practitioner: frm.doc.ordered_by,
+					practitioner: frm.doc.practitioner,
 				},
 			};
 		});
@@ -167,9 +167,9 @@ frappe.ui.form.on(cur_frm.doctype, {
 		}
 	},
 
-	birth_date: function (frm) {
-		let age_str = calculate_age(frm.doc.birth_date);
-		frm.set_value("patient_age", age_str);
+	patient_birth_date: function (frm) {
+		let age_str = calculate_age(frm.doc.patient_birth_date);
+		frm.set_value("patient_age_data", age_str);
 	},
 });
 


### PR DESCRIPTION
- Move shared Service Request client logic to healthcare/healthcare/service_request.js
- Updated all import paths across the codebase to reflect new location
- Refactored practitioner field reference from ordered_by to practitioner in service request filters
- Changed birth_date function to patient_birth_date and updated related variable names
- Replaced dateutil.relativedelta with month_diff utility for patient age calculation
- Update pre-commit config to exclude service_request.js from checks