### PR TITLE
fix: Make discharge summary non mandatory before discharge

### DIFF
--- a/healthcare/healthcare/doctype/discharge_summary/discharge_summary.py
+++ b/healthcare/healthcare/doctype/discharge_summary/discharge_summary.py
@@ -64,22 +64,3 @@ class DischargeSummary(Document):
 					self.chief_complaint = []
 					for symptom in encounter.symptoms:
 						self.append("chief_complaint", (frappe.copy_doc(symptom)).as_dict())
-
-
-@frappe.whitelist()
-def has_discharge_summary(inpatient_record):
-	if frappe.db.exists("Discharge Summary", {"docstatus": 1, "inpatient_record": inpatient_record}):
-		return True
-
-	draft_summary = frappe.db.exists(
-		"Discharge Summary", {"docstatus": 0, "inpatient_record": inpatient_record}
-	)
-	message = (
-		_(
-			f"A draft Discharge Summary exists. To proceed, please submit: {get_link_to_form('Discharge Summary', draft_summary)}"
-		)
-		if draft_summary
-		else _("Please submit a Discharge Summary to proceed with discharging the patient.")
-	)
-
-	frappe.throw(message)

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
@@ -133,17 +133,7 @@ frappe.ui.form.on("Inpatient Record", {
 						}
 					});
 				frm.add_custom_button(__("Discharge"), function () {
-					frappe.call({
-						method: "healthcare.healthcare.doctype.discharge_summary.discharge_summary.has_discharge_summary",
-						args: {
-							inpatient_record: frm.doc.name,
-						},
-						callback: function (r) {
-							if (r) {
-								discharge_patient(frm);
-							}
-						},
-					});
+					discharge_patient(frm);
 				});
 				if (frm.doc.insurance_policy) {
 					frm.add_custom_button(__("Create Insurance Coverage"), function () {


### PR DESCRIPTION
Making Discharge Summary Mandatory before discharge is not a good idea. It will make the bed occupancy cumbersome. Hospitals take time to prepare the discharge summary and they will not want the bed to be occupied until then.