### PR TITLE
fix: sidebar layout in Patient History and Patient Progress pages

### DIFF
--- a/healthcare/healthcare/page/patient_history/patient_history.css
+++ b/healthcare/healthcare/page/patient_history/patient_history.css
@@ -149,3 +149,16 @@
 #page-medical_record .list-filters {
 	display: none;
 }
+
+.layout-side-section {
+	display: block !important;
+	padding: 10px;
+	width: 20%;
+	flex: 0 0 20%;
+}
+
+.layout-main-section-wrapper {
+	flex: 1;
+	width: 80%;
+	max-width: 80%;
+}

--- a/healthcare/healthcare/page/patient_history/patient_history.js
+++ b/healthcare/healthcare/page/patient_history/patient_history.js
@@ -24,6 +24,13 @@ class PatientHistory {
 		frappe.breadcrumbs.add("Healthcare");
 		this.sidebar.empty();
 
+		this.wrapper.find(".patient-history-heading").remove();
+		$(
+			`<h2 class="patient-history-heading" style="margin-top: 15px; margin-bottom: 10px; padding-left: 10px; font-size: 20px; font-weight: 600;">${__(
+				"Patient History",
+			)}</h2>`,
+		).insertBefore(this.sidebar.parent());
+
 		let me = this;
 		let patient = frappe.ui.form.make_control({
 			parent: me.sidebar,

--- a/healthcare/healthcare/page/patient_progress/patient_progress.css
+++ b/healthcare/healthcare/page/patient_progress/patient_progress.css
@@ -169,3 +169,16 @@ text.title {
 		width: 40%;
 	}
 }
+
+.layout-side-section {
+	display: block !important;
+	padding: 10px;
+	width: 20%;
+	flex: 0 0 20%;
+}
+
+.layout-main-section-wrapper {
+	flex: 1;
+	width: 80%;
+	max-width: 80%;
+}

--- a/healthcare/healthcare/page/patient_progress/patient_progress.js
+++ b/healthcare/healthcare/page/patient_progress/patient_progress.js
@@ -22,6 +22,13 @@ class PatientProgress {
 		frappe.breadcrumbs.add("Healthcare");
 		this.sidebar.empty();
 
+		this.wrapper.find(".patient-progress-heading").remove();
+		$(
+			`<h2 class="patient-progress-heading" style="margin-top: 15px; margin-bottom: 10px; padding-left: 10px; font-size: 20px; font-weight: 600;">${__(
+				"Patient Progress",
+			)}</h2>`,
+		).insertBefore(this.sidebar.parent());
+
 		let me = this;
 		let patient = frappe.ui.form.make_control({
 			parent: me.sidebar,


### PR DESCRIPTION
- Fixed sidebar and main section layout styles to fix missing sidebar issue in Patient History and Patient Progress
- Added page headings above sidebar to align with layout