### PR TITLE
fix: use of uninitialized variable in case of practitioner availability

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -726,6 +726,7 @@ def get_availability_data(date, practitioner, appointment):
 	):
 		available_slotes = get_availability_slots(practitioner_doc, date, appointment.appointment_type)
 
+	slot_details = []
 	if practitioner_doc.practitioner_schedules:
 		slot_details = get_available_slots(practitioner_doc, date)
 	elif not len(available_slotes):


### PR DESCRIPTION
Error: `UnboundLocalError: cannot access local variable 'slot_details' where it is not associated with a value`