### PR TITLE
fix: Sample collection status not updating to Collected when sample name and sample type are different

### DIFF
--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -241,7 +241,7 @@ def create_specimen(patient, selected, component_observations):
 		specimen = frappe.new_doc("Specimen")
 		specimen.received_time = now_datetime()
 		specimen.patient = patient
-		specimen.specimen_type = groups[gr][0].get("sample_type")
+		specimen.specimen_type = (groups[gr][0].get("sample") or groups[gr][0].get("sample_type"))
 		specimen.save()
 		for sub_grp in groups[gr]:
 			if component_observations:

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -241,7 +241,7 @@ def create_specimen(patient, selected, component_observations):
 		specimen = frappe.new_doc("Specimen")
 		specimen.received_time = now_datetime()
 		specimen.patient = patient
-		specimen.specimen_type = (groups[gr][0].get("sample") or groups[gr][0].get("sample_type"))
+		specimen.specimen_type = groups[gr][0].get("sample") or groups[gr][0].get("sample_type")
 		specimen.save()
 		for sub_grp in groups[gr]:
 			if component_observations:


### PR DESCRIPTION
Issue:
When Sample name (sample) and Sample Type (sample_type) are different, clicking Mark Collected leaves the Sample Collection status as Partly Collected. Specimen creation happens in a background job (frappe.enqueue) and fails to link correctly if specimen.specimen_type uses sample_type.

Fix:
Setted specimen.specimen_type using the Sample field (sample) or sample_type, ensuring correct specimen mapping and proper update of Sample Collection status to Collected even when sample and sample_type differ. Specimen Type field present in Specimen form contains a dropdown with sample name(sample)