### PR TITLE
fix: queue number resets to 1 after previous appointments closed for queue-based practitioner

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -471,10 +471,7 @@ class PatientAppointment(Document):
 			.select(
 				Max(appointment.position_in_queue).as_("max_position"),
 			)
-			.where(
-				(appointment.appointment_date == self.appointment_date)
-				& (appointment.name != self.name)
-			)
+			.where((appointment.appointment_date == self.appointment_date) & (appointment.name != self.name))
 		)
 
 		if self.appointment_for == "Practitioner":

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -471,7 +471,10 @@ class PatientAppointment(Document):
 			.select(
 				Max(appointment.position_in_queue).as_("max_position"),
 			)
-			.where((appointment.appointment_date == self.appointment_date)& (appointment.name != self.name))
+			.where(
+				(appointment.appointment_date == self.appointment_date)
+				& (appointment.name != self.name)
+			)
 		)
 
 		if self.appointment_for == "Practitioner":

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -471,7 +471,7 @@ class PatientAppointment(Document):
 			.select(
 				Max(appointment.position_in_queue).as_("max_position"),
 			)
-			.where((appointment.status == "Checked In") & (appointment.name != self.name))
+			.where((appointment.appointment_date == self.appointment_date)& (appointment.name != self.name))
 		)
 
 		if self.appointment_for == "Practitioner":


### PR DESCRIPTION
Issue Description

When a practitioner is configured with a queue-based schedule in the Patient Appointment form:
     1.If 3 patients check in for Doctor A, their queue numbers are correctly assigned as 1, 2, and 3.
     2.After these appointments are completed and their status is changed to Closed,
     3.When a new (fourth) patient checks in for the same doctor, the system incorrectly resets the Number in Queue to 1 instead of   continuing the sequence to 4.

Expected Behavior:
Queue numbering should remain sequential for the practitioner and continue from the last assigned number, even if previous appointments are marked as Closed.

Current Behavior:
Queue numbering restarts from 1 once earlier appointments are closed.

Resolution
This was resolved by modifying the queue calculation logic to consider all appointments for the same date instead of only “Checked In” status: