### PR TITLE
fix: Add Sales Invoice creation button in Service Request

### DIFF
--- a/healthcare/healthcare/doctype/service_request/service_request.js
+++ b/healthcare/healthcare/doctype/service_request/service_request.js
@@ -255,6 +255,20 @@ frappe.ui.form.on("Service Request", {
 				__("Create"),
 			);
 		}
+		// SALES INVOICE BUTTON 
+		if (frm.doc.docstatus === 1 && frm.doc.billing_status !== "Invoiced") {
+			frm.add_custom_button(
+				__("Sales Invoice"),
+				function () {
+					frappe.model.open_mapped_doc({
+						method: "healthcare.healthcare.doctype.service_request.service_request.make_sales_invoice",
+						frm: frm
+					});
+				},
+				__("Create")
+			);
+		}
+
 
 		frm.page.set_inner_btn_group_as_primary(__("Create"));
 	},

--- a/healthcare/healthcare/doctype/service_request/service_request.js
+++ b/healthcare/healthcare/doctype/service_request/service_request.js
@@ -255,19 +255,46 @@ frappe.ui.form.on("Service Request", {
 				__("Create"),
 			);
 		}
-		// SALES INVOICE BUTTON 
+		// SALES INVOICE BUTTON
 		if (frm.doc.docstatus === 1 && frm.doc.billing_status !== "Invoiced") {
 			frm.add_custom_button(
 				__("Sales Invoice"),
 				function () {
-					frappe.model.open_mapped_doc({
-						method: "healthcare.healthcare.doctype.service_request.service_request.make_sales_invoice",
-						frm: frm
+
+					//  Check if Sales Invoice already exists
+					frappe.db.get_value(
+						"Sales Invoice Item",
+						{
+							reference_dt: "Service Request",
+							reference_dn: frm.doc.name,
+							docstatus: ["!=", 2] // not cancelled
+						},
+						"parent"
+					).then(r => {
+
+						// If already exists → open existing invoice
+						if (r.message && r.message.parent) {
+							frappe.set_route("Form", "Sales Invoice", r.message.parent);
+							frappe.show_alert({
+								message: __("Sales Invoice already created"),
+								indicator: "blue"
+							});
+						}
+
+						// If not exists → create new
+						else {
+							frappe.model.open_mapped_doc({
+								method: "healthcare.healthcare.doctype.service_request.service_request.make_sales_invoice",
+								frm: frm
+							});
+						}
+
 					});
 				},
 				__("Create")
 			);
 		}
+
 
 
 		frm.page.set_inner_btn_group_as_primary(__("Create"));

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -7,8 +7,8 @@ import json
 import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import now_datetime, nowdate
 from frappe.model.naming import get_default_naming_series
+from frappe.utils import now_datetime, nowdate
 
 from healthcare.controllers.service_request_controller import ServiceRequestController
 from healthcare.healthcare.doctype.observation.observation import add_observation

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -470,6 +470,7 @@ def make_appointment(source_name, target_doc=None, ignore_permissions=False):
 
 	return doclist
 
+
 @frappe.whitelist()
 def make_sales_invoice(source_name, target_doc=None):
 	service_request = source_name
@@ -541,7 +542,6 @@ def make_sales_invoice(source_name, target_doc=None):
 			},
 		)
 
-
 	doc = get_mapped_doc(
 		"Service Request",
 		sr.name,
@@ -552,7 +552,6 @@ def make_sales_invoice(source_name, target_doc=None):
 		},
 		target_doc=target_doc,
 		postprocess=postprocess,
-
 	)
 
 	doc.set_missing_values(for_validate=True)

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -7,8 +7,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import now_datetime
-from frappe.utils import nowdate  
+from frappe.utils import now_datetime, nowdate 
 
 from healthcare.controllers.service_request_controller import ServiceRequestController
 from healthcare.healthcare.doctype.observation.observation import add_observation
@@ -479,6 +478,9 @@ def make_sales_invoice(source_name, target_doc=None):
 
 	sr = frappe.get_doc("Service Request", service_request)
 
+	if sr.billing_status == "Invoiced":
+		frappe.throw(_("Service Request {0} is already invoiced").format(sr.name))
+		
 	if not sr.template_dn:
 		frappe.throw(_("Template not selected"))
 

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -472,7 +472,7 @@ def make_appointment(source_name, target_doc=None, ignore_permissions=False):
 
 
 @frappe.whitelist()
-def make_sales_invoice(source_name, target_doc=None):
+def make_sales_invoice(source_name: str, target_doc: dict | None = None):
 	service_request = source_name
 	if not service_request:
 		return

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -7,7 +7,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import now_datetime, nowdate 
+from frappe.utils import now_datetime, nowdate
 
 from healthcare.controllers.service_request_controller import ServiceRequestController
 from healthcare.healthcare.doctype.observation.observation import add_observation
@@ -479,7 +479,8 @@ def make_sales_invoice(source_name, target_doc=None):
 	sr = frappe.get_doc("Service Request", service_request)
 
 	if sr.billing_status == "Invoiced":
-		frappe.throw(_("Service Request {0} is already invoiced").format(sr.name))		
+		frappe.throw(_("Service Request {0} is already invoiced").format(sr.name))
+
 	if not sr.template_dn:
 		frappe.throw(_("Template not selected"))
 

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import now_datetime
+from frappe.utils import nowdate  
 
 from healthcare.controllers.service_request_controller import ServiceRequestController
 from healthcare.healthcare.doctype.observation.observation import add_observation
@@ -469,3 +470,66 @@ def make_appointment(source_name, target_doc=None, ignore_permissions=False):
 	)
 
 	return doclist
+
+@frappe.whitelist()
+def make_sales_invoice(service_request):
+	if not service_request:
+		return
+
+	sr = frappe.get_doc("Service Request", service_request)
+
+	if not sr.template_dn:
+		frappe.throw("Template not selected")
+
+	# fetch template
+	template = frappe.get_doc(sr.template_dt, sr.template_dn)
+
+	# check if template is billable
+	if not template.get("is_billable"):
+		frappe.throw(f"Template '{sr.template_dn}' is not marked as Billable")
+
+	item_code = template.get("item")
+
+	if not item_code:
+		frappe.throw(f"{sr.template_dn} is not set as billable")
+
+	item_doc = frappe.get_doc("Item", item_code)
+	rate = template.get("rate") 
+
+
+
+	def postprocess(source, target):
+		uom = item_doc.stock_uom 
+
+		target.company = sr.company
+		target.patient = sr.patient
+		target.customer = sr.patient
+		target.due_date = nowdate()   
+
+		target.append("items", {
+			"item_code": item_doc.name,
+			"item_name": item_doc.item_name,
+			"description": sr.template_dn,
+			"qty": sr.quantity or 1,
+			"rate": rate,
+			"uom": uom,
+			"stock_uom": uom,
+			"income_account": frappe.get_cached_value("Company", sr.company, "default_income_account"),
+			"cost_center": frappe.get_cached_value("Company", sr.company, "cost_center"),
+			"reference_dt": "Service Request",
+			"reference_dn": sr.name,
+		})
+
+	doc = get_mapped_doc(
+		"Service Request",
+		sr.name,
+		{
+			"Service Request": {
+				"doctype": "Sales Invoice",
+			}
+		},
+		target_doc=None,
+		postprocess=postprocess
+	)
+
+	return doc

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import now_datetime, nowdate
+from frappe.model.naming import get_default_naming_series
 
 from healthcare.controllers.service_request_controller import ServiceRequestController
 from healthcare.healthcare.doctype.observation.observation import add_observation
@@ -554,5 +555,10 @@ def make_sales_invoice(source_name: str, target_doc: dict | None = None):
 		postprocess=postprocess,
 	)
 
+	# REMOVE inherited Service Request series
+	doc.naming_series = None
+	doc.name = None
+
 	doc.set_missing_values(for_validate=True)
+	doc.naming_series = get_default_naming_series("Sales Invoice")
 	return doc

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -479,8 +479,7 @@ def make_sales_invoice(source_name, target_doc=None):
 	sr = frappe.get_doc("Service Request", service_request)
 
 	if sr.billing_status == "Invoiced":
-		frappe.throw(_("Service Request {0} is already invoiced").format(sr.name))
-		
+		frappe.throw(_("Service Request {0} is already invoiced").format(sr.name))		
 	if not sr.template_dn:
 		frappe.throw(_("Template not selected"))
 
@@ -550,4 +549,5 @@ def make_sales_invoice(source_name, target_doc=None):
 		postprocess=postprocess
 	)
 
+	doc.set_missing_values(for_validate=True)
 	return doc

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -524,19 +524,23 @@ def make_sales_invoice(source_name, target_doc=None):
 
 		target.due_date = nowdate()
 
-		target.append("items", {
-			"item_code": item_doc.name,
-			"item_name": item_doc.item_name,
-			"description": sr.template_dn,
-			"qty": sr.quantity or 1,
-			"rate": rate,
-			"uom": uom,
-			"stock_uom": uom,
-			"income_account": frappe.get_cached_value("Company", sr.company, "default_income_account"),
-			"cost_center": frappe.get_cached_value("Company", sr.company, "cost_center"),
-			"reference_dt": "Service Request",
-			"reference_dn": sr.name,
-		})
+		target.append(
+			"items",
+			{
+				"item_code": item_doc.name,
+				"item_name": item_doc.item_name,
+				"description": sr.template_dn,
+				"qty": sr.quantity or 1,
+				"rate": rate,
+				"uom": uom,
+				"stock_uom": uom,
+				"income_account": frappe.get_cached_value("Company", sr.company, "default_income_account"),
+				"cost_center": frappe.get_cached_value("Company", sr.company, "cost_center"),
+				"reference_dt": "Service Request",
+				"reference_dn": sr.name,
+			},
+		)
+
 
 	doc = get_mapped_doc(
 		"Service Request",
@@ -547,7 +551,8 @@ def make_sales_invoice(source_name, target_doc=None):
 			}
 		},
 		target_doc=target_doc,
-		postprocess=postprocess
+		postprocess=postprocess,
+
 	)
 
 	doc.set_missing_values(for_validate=True)

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -472,39 +472,55 @@ def make_appointment(source_name, target_doc=None, ignore_permissions=False):
 	return doclist
 
 @frappe.whitelist()
-def make_sales_invoice(service_request):
+def make_sales_invoice(source_name, target_doc=None):
+	service_request = source_name
 	if not service_request:
 		return
 
 	sr = frappe.get_doc("Service Request", service_request)
 
 	if not sr.template_dn:
-		frappe.throw("Template not selected")
+		frappe.throw(_("Template not selected"))
 
 	# fetch template
 	template = frappe.get_doc(sr.template_dt, sr.template_dn)
 
-	# check if template is billable
-	if not template.get("is_billable"):
-		frappe.throw(f"Template '{sr.template_dn}' is not marked as Billable")
+	# safe billable check (only if field exists)
+	if template.meta.has_field("is_billable"):
+		if not template.get("is_billable"):
+			frappe.throw(_("Template '{0}' is not marked as Billable").format(sr.template_dn))
 
+	# item
 	item_code = template.get("item")
-
 	if not item_code:
-		frappe.throw(f"{sr.template_dn} is not set as billable")
+		frappe.throw(_("{0} is not set as billable").format(sr.template_dn))
 
 	item_doc = frappe.get_doc("Item", item_code)
-	rate = template.get("rate") 
 
+	# rate fallback logic (IMPORTANT FIX)
+	rate = template.get("rate")
 
+	if not rate or rate == 0:
+		rate = item_doc.standard_rate or 0
+
+	if not rate or rate == 0:
+		frappe.throw(_("Rate not found in template or Item Price for item {0}").format(item_code))
+
+	# get customer from patient (CRITICAL FIX)
+	customer = frappe.db.get_value("Patient", sr.patient, "customer")
+	if not customer:
+		frappe.throw(_("Patient is not linked to any Customer"))
 
 	def postprocess(source, target):
-		uom = item_doc.stock_uom 
+		uom = item_doc.stock_uom
 
 		target.company = sr.company
 		target.patient = sr.patient
-		target.customer = sr.patient
-		target.due_date = nowdate()   
+
+		# FIX: correct customer
+		target.customer = customer
+
+		target.due_date = nowdate()
 
 		target.append("items", {
 			"item_code": item_doc.name,
@@ -528,7 +544,7 @@ def make_sales_invoice(service_request):
 				"doctype": "Sales Invoice",
 			}
 		},
-		target_doc=None,
+		target_doc=target_doc,
 		postprocess=postprocess
 	)
 

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -7,7 +7,6 @@ import json
 import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
-from frappe.model.naming import get_default_naming_series
 from frappe.utils import now_datetime, nowdate
 
 from healthcare.controllers.service_request_controller import ServiceRequestController
@@ -549,16 +548,12 @@ def make_sales_invoice(source_name: str, target_doc: dict | None = None):
 		{
 			"Service Request": {
 				"doctype": "Sales Invoice",
+				"field_no_map": ["naming_series"],
 			}
 		},
 		target_doc=target_doc,
 		postprocess=postprocess,
 	)
 
-	# REMOVE inherited Service Request series
-	doc.naming_series = None
-	doc.name = None
-
 	doc.set_missing_values(for_validate=True)
-	doc.naming_series = get_default_naming_series("Sales Invoice")
 	return doc


### PR DESCRIPTION
Overview:-
Previously, creating a Sales Invoice for a Service Request required manual navigation to the Sales Invoice doctype and using the “Get Items From” option, which was time-consuming and inefficient.

This PR introduces a “Create Sales Invoice” button directly in the Service Request form to streamline the billing workflow.

Changes Implemented:-
1.Added Create Sales Invoice button in Service Request.
2.On click, the system automatically:
     Fetches item details (item, item code, rate, etc.) from the selected template (e.g., CBC Lab Test).
     Creates a Sales Invoice if the selected template is marked as billable.
3.Added validation:
     If the selected template has Is Billable = unchecked, the system will show the message:
    “Template X is not marked as Billable.”

Benefits:-
1.Eliminates manual navigation to Sales Invoice.
2.Reduces time required for invoice creation.
3.Improves billing workflow efficiency.
4.Ensures invoices are created only for billable templates.