### PR TITLE
fix: Auto refresh service request after invoice submit

### DIFF
--- a/healthcare/healthcare/doctype/service_request/service_request.js
+++ b/healthcare/healthcare/doctype/service_request/service_request.js
@@ -5,6 +5,15 @@
 
 frappe.ui.form.on("Service Request", {
 	refresh: function (frm) {
+		// AUTO REFRESH AFTER INVOICE SUBMIT
+		if (!frm.is_new() && frm.doc.docstatus == 1) {
+			frappe.db.get_value("Service Request", frm.doc.name, "billing_status")
+			.then(r => {
+				if (r.message && r.message.billing_status !== frm.doc.billing_status) {
+					frm.reload_doc();
+				}
+			});
+		}
 		if (
 			!frm.is_new() &&
 			!frm.doc.insurance_policy &&


### PR DESCRIPTION
After creating and submitting a Sales Invoice for a Service Request, the billing status updates correctly in the backend. However, when returning to the Service Request using the browser back button (<-), the updated billing status is not reflected unless the page is manually refreshed.

This fix ensures the Service Request form reloads the latest data from the server when revisited, so the billing status is always shown correctly without requiring a manual refresh.