### PR TITLE
Feat: Combine Registration Fee with Consultation Fee for New Patient Appointment Billing

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
@@ -515,7 +515,7 @@
   },
   {
    "default": "0",
-   "description": "Checking this will merge the registration fee with consultation fee for new patient.",
+   "description": "If enabled, new patients will be created in active state and the registration fee will be added together with the consultation fee in a single Sales Invoice instead of creating a separate registration invoice.",
    "fieldname": "include_registration_fee",
    "fieldtype": "Check",
    "label": "Include Registration Fee with Consultation fee"
@@ -539,7 +539,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2026-03-09 09:51:12.770033",
+ "modified": "2026-03-09 14:14:03.585493",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Healthcare Settings",

--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
@@ -534,12 +534,14 @@
    "fieldname": "reg_fee",
    "fieldtype": "Currency",
    "label": "Registration Fee",
-   "mandatory_depends_on": "eval:doc.include_registration_fee==1"
+   "mandatory_depends_on": "eval:doc.include_registration_fee==1",
+   "non_negative": 1,
+   "options": "Currency"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2026-03-09 14:14:03.585493",
+ "modified": "2026-03-09 14:39:26.209372",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Healthcare Settings",

--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
@@ -20,6 +20,9 @@
   "enable_free_follow_ups",
   "max_visits",
   "valid_days",
+  "include_registration_fee",
+  "reg_item",
+  "reg_fee",
   "inpatient_settings_section",
   "allow_discharge_despite_unbilled_services",
   "allow_discharge_despite_pending_healthcare_services",
@@ -509,11 +512,34 @@
    "label": "Registration Item",
    "mandatory_depends_on": "eval:doc.collect_registration_fee == 1",
    "options": "Item"
+  },
+  {
+   "default": "0",
+   "description": "Checking this will merge the registration fee with consultation fee for new patient.",
+   "fieldname": "include_registration_fee",
+   "fieldtype": "Check",
+   "label": "Include Registration Fee with Consultation fee"
+  },
+  {
+   "depends_on": "eval:doc.include_registration_fee==1",
+   "fieldname": "reg_item",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Registration Item",
+   "mandatory_depends_on": "eval:doc.include_registration_fee==1",
+   "options": "Item"
+  },
+  {
+   "depends_on": "eval:doc.include_registration_fee==1",
+   "fieldname": "reg_fee",
+   "fieldtype": "Currency",
+   "label": "Registration Fee",
+   "mandatory_depends_on": "eval:doc.include_registration_fee==1"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2025-12-25 09:36:33.073374",
+ "modified": "2026-03-09 09:51:12.770033",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Healthcare Settings",

--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.py
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.py
@@ -50,8 +50,8 @@ class HealthcareSettings(Document):
 			if item_values.get("is_stock_item") or item_values.get("has_stock"):
 				frappe.throw(_("Configure a service Item for {0}").format(self.get("reg_item")))
 
-			if self.get("reg_fee") is not None and self.get("reg_fee") < 0:
-				frappe.throw(_("Registration Fee cannot be less than 0"))
+			if self.get("reg_fee") is not None and self.get("reg_fee") <= 0:
+				frappe.throw(_("Registration Fee cannot be negative or zero"))
 
 		if self.inpatient_visit_charge_item:
 			validate_service_item(self.inpatient_visit_charge_item)

--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.py
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.py
@@ -29,7 +29,6 @@ class HealthcareSettings(Document):
 			if self.registration_fee <= 0:
 				frappe.throw(_("Registration Fee cannot be negative or zero"))
 
-
 		# registration fee fields: validate required service item and fee.
 		if (
 			self.meta.has_field("include_registration_fee")

--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.py
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.py
@@ -29,6 +29,12 @@ class HealthcareSettings(Document):
 			if self.registration_fee <= 0:
 				frappe.throw(_("Registration Fee cannot be negative or zero"))
 
+
+		# Custom registration fee fields: disallow negative values.
+		if self.meta.has_field("include_registration_fee") and self.meta.has_field("reg_fee"):
+			if self.get("include_registration_fee") and self.get("reg_fee") is not None and self.get("reg_fee") <= 0:
+				frappe.throw(_("Registration Fee cannot be negative or zero"))
+
 		if self.inpatient_visit_charge_item:
 			validate_service_item(self.inpatient_visit_charge_item)
 		if self.op_consulting_charge_item:

--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.py
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.py
@@ -30,10 +30,29 @@ class HealthcareSettings(Document):
 				frappe.throw(_("Registration Fee cannot be negative or zero"))
 
 
-		# Custom registration fee fields: disallow negative values.
-		if self.meta.has_field("include_registration_fee") and self.meta.has_field("reg_fee"):
-			if self.get("include_registration_fee") and self.get("reg_fee") is not None and self.get("reg_fee") <= 0:
-				frappe.throw(_("Registration Fee cannot be negative or zero"))
+		# registration fee fields: validate required service item and fee.
+		if (
+			self.meta.has_field("include_registration_fee")
+			and self.meta.has_field("reg_fee")
+			and self.meta.has_field("reg_item")
+			and self.get("include_registration_fee")
+		):
+			if not self.get("reg_item"):
+				frappe.throw(_("Please set a Registration Item"))
+
+			if not frappe.db.exists("Item", self.get("reg_item")):
+				frappe.throw(_("Registration Item {0} does not exist").format(self.get("reg_item")))
+
+			item_meta = frappe.get_meta("Item")
+			item_fields = ["is_stock_item"]
+			if item_meta.has_field("has_stock"):
+				item_fields.append("has_stock")
+			item_values = frappe.db.get_value("Item", self.get("reg_item"), item_fields, as_dict=True) or {}
+			if item_values.get("is_stock_item") or item_values.get("has_stock"):
+				frappe.throw(_("Configure a service Item for {0}").format(self.get("reg_item")))
+
+			if self.get("reg_fee") is not None and self.get("reg_fee") < 0:
+				frappe.throw(_("Registration Fee cannot be less than 0"))
 
 		if self.inpatient_visit_charge_item:
 			validate_service_item(self.inpatient_visit_charge_item)

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -1524,8 +1524,8 @@ let make_payment = function (frm, automate_invoicing) {
 				} else {
 					d.get_primary_btn().attr("disabled", false);
 					if (!frm.via_discount_percentage) {
-						discount_percentage = total_charge 
-							? (discount_amount / total_charge) * 100 
+						discount_percentage = total_charge
+							? (discount_amount / total_charge) * 100
 							: 0;
 						d.set_values({
 							discount_percentage: discount_percentage,

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -1383,7 +1383,6 @@ let make_payment = function (frm, automate_invoicing) {
 		}
 	}
 
-
 	async function show_payment_dialog(frm, fields) {
 		let registration_fee = 0;
 		let registration_data = (
@@ -1521,13 +1520,13 @@ let make_payment = function (frm, automate_invoicing) {
 			} else if (field === "discount_amount") {
 				if (total_charge < discount_amount || discount_amount < 0) {
 					d.get_primary_btn().attr("disabled", true);
-					message =
-						"Discount amount should not be more than Total Charge";
+					message = "Discount amount should not be more than Total Charge";
 				} else {
 					d.get_primary_btn().attr("disabled", false);
 					if (!frm.via_discount_percentage) {
-						discount_percentage =
-							total_charge ? (discount_amount / total_charge) * 100 : 0;
+						discount_percentage = total_charge 
+							? (discount_amount / total_charge) * 100 
+							: 0;
 						d.set_values({
 							discount_percentage: discount_percentage,
 							total_payable: total_charge - discount_amount,
@@ -1538,7 +1537,6 @@ let make_payment = function (frm, automate_invoicing) {
 			show_message(d, message, field);
 		}
 	}
-
 };
 
 let show_message = function (d, message, field) {

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -1383,7 +1383,33 @@ let make_payment = function (frm, automate_invoicing) {
 		}
 	}
 
-	function show_payment_dialog(frm, fields) {
+
+	async function show_payment_dialog(frm, fields) {
+		let registration_fee = 0;
+		let registration_data = (
+			await frappe.call({
+				method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.get_registration_fee_details",
+				args: {
+					appointment_name: frm.doc.name,
+				},
+			})
+		).message;
+
+		if (registration_data?.apply_registration_fee) {
+			registration_fee = flt(registration_data.registration_fee);
+			let total_payable_index = fields.findIndex(
+				field => field.fieldname === "total_payable",
+			);
+			if (total_payable_index > -1) {
+				fields.splice(total_payable_index, 0, {
+					label: "Registration Fee",
+					fieldname: "registration_fee",
+					fieldtype: "Currency",
+					read_only: true,
+				});
+			}
+		}
+
 		let d = new frappe.ui.Dialog({
 			title: "Enter Payment Details",
 			fields: fields,
@@ -1439,11 +1465,15 @@ let make_payment = function (frm, automate_invoicing) {
 			}
 		};
 		d.get_secondary_btn().attr("disabled", true);
-		d.set_values({
+		let dialog_values = {
 			patient: frm.doc.patient_name,
 			consultation_charge: frm.doc.paid_amount,
-			total_payable: frm.doc.paid_amount,
-		});
+			total_payable: flt(frm.doc.paid_amount) + registration_fee,
+		};
+		if (d.get_field("registration_fee")) {
+			dialog_values.registration_fee = registration_fee;
+		}
+		d.set_values(dialog_values);
 
 		if (frm.doc.appointment_for == "Practitioner") {
 			d.set_value("practitioner", frm.doc.practitioner_name);
@@ -1467,7 +1497,9 @@ let make_payment = function (frm, automate_invoicing) {
 			let message = "";
 			let discount_percentage = d.get_value("discount_percentage");
 			let discount_amount = d.get_value("discount_amount");
-			let consultation_charge = d.get_value("consultation_charge");
+			let consultation_charge = flt(d.get_value("consultation_charge"));
+			let registration_fee = flt(d.get_value("registration_fee")) || 0;
+			let total_charge = consultation_charge + registration_fee;
 
 			if (field === "discount_percentage") {
 				if (discount_percentage > 100 || discount_percentage < 0) {
@@ -1479,26 +1511,26 @@ let make_payment = function (frm, automate_invoicing) {
 					if (discount_percentage && discount_amount) {
 						d.set_value("discount_amount", 0);
 					}
-					discount_amount = consultation_charge * (discount_percentage / 100);
+					discount_amount = total_charge * (discount_percentage / 100);
 
 					d.set_values({
 						discount_amount: discount_amount,
-						total_payable: consultation_charge - discount_amount,
+						total_payable: total_charge - discount_amount,
 					}).then(() => delete frm.via_discount_percentage);
 				}
 			} else if (field === "discount_amount") {
-				if (consultation_charge < discount_amount || discount_amount < 0) {
+				if (total_charge < discount_amount || discount_amount < 0) {
 					d.get_primary_btn().attr("disabled", true);
 					message =
-						"Discount amount should not be more than Consultation Charge";
+						"Discount amount should not be more than Total Charge";
 				} else {
 					d.get_primary_btn().attr("disabled", false);
 					if (!frm.via_discount_percentage) {
 						discount_percentage =
-							(discount_amount / consultation_charge) * 100;
+							total_charge ? (discount_amount / total_charge) * 100 : 0;
 						d.set_values({
 							discount_percentage: discount_percentage,
-							total_payable: consultation_charge - discount_amount,
+							total_payable: total_charge - discount_amount,
 						});
 					}
 				}
@@ -1506,6 +1538,7 @@ let make_payment = function (frm, automate_invoicing) {
 			show_message(d, message, field);
 		}
 	}
+
 };
 
 let show_message = function (d, message, field) {

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -546,7 +546,7 @@ def invoice_appointment(appointment_name, discount_percentage=0, discount_amount
 
 
 @frappe.whitelist()
-def get_registration_fee_details(appointment_name):
+def get_registration_fee_details(appointment_name: str) -> dict:
 	appointment_doc = frappe.get_doc("Patient Appointment", appointment_name)
 	registration_context = get_registration_fee_context(appointment_doc)
 	return {

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -13,6 +13,7 @@ from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import (
 	add_to_date,
+	cint,
 	flt,
 	format_date,
 	get_datetime,
@@ -544,6 +545,16 @@ def invoice_appointment(appointment_name, discount_percentage=0, discount_amount
 	update_fee_validity(appointment_doc)
 
 
+
+@frappe.whitelist()
+def get_registration_fee_details(appointment_name):
+	appointment_doc = frappe.get_doc("Patient Appointment", appointment_name)
+	registration_context = get_registration_fee_context(appointment_doc)
+	return {
+		"apply_registration_fee": registration_context.get("apply_registration_fee"),
+		"registration_fee": registration_context.get("registration_fee"),
+	}
+
 def create_sales_invoice(appointment_doc, discount_percentage=0, discount_amount=0):
 	sales_invoice = frappe.new_doc("Sales Invoice")
 	sales_invoice.patient = appointment_doc.patient
@@ -556,19 +567,23 @@ def create_sales_invoice(appointment_doc, discount_percentage=0, discount_amount
 	item = sales_invoice.append("items", {})
 	item = get_appointment_item(appointment_doc, item)
 
-	paid_amount = flt(appointment_doc.paid_amount)
+	registration_context = get_registration_fee_context(appointment_doc)
+	registration_fee = flt(registration_context.get("registration_fee"))
+	paid_amount = flt(appointment_doc.paid_amount) + registration_fee
+
+	if registration_context.get("apply_registration_fee"):
+		reg_item = sales_invoice.append("items", {})
+		reg_item = get_registration_item(appointment_doc, reg_item, registration_context)
 	# Set discount amount and percentage if entered in payment popup
 	if flt(discount_percentage):
 		sales_invoice.additional_discount_percentage = flt(discount_percentage)
-		paid_amount = flt(appointment_doc.paid_amount) - (
-			flt(appointment_doc.paid_amount) * (flt(discount_percentage) / 100)
-		)
+		paid_amount = paid_amount - (paid_amount * (flt(discount_percentage) / 100))
 	if flt(discount_amount):
 		sales_invoice.discount_amount = flt(discount_amount)
-		paid_amount = flt(appointment_doc.paid_amount) - flt(discount_amount)
+		paid_amount = paid_amount - flt(discount_amount)
 
 	# Add payments if payment details are supplied else proceed to create invoice as Unpaid
-	if appointment_doc.mode_of_payment and appointment_doc.paid_amount:
+	if appointment_doc.mode_of_payment and paid_amount:
 		sales_invoice.is_pos = 1
 		payment = sales_invoice.append("payments", {})
 		payment.mode_of_payment = appointment_doc.mode_of_payment
@@ -631,6 +646,75 @@ def get_appointment_item(appointment_doc, item):
 	return item
 
 
+
+def get_registration_item(appointment_doc, item, registration_context):
+	item.item_code = registration_context.get("registration_item")
+	item.description = _("Registration Charges")
+	item.income_account = get_income_account(appointment_doc.practitioner, appointment_doc.company)
+	item.cost_center = frappe.get_cached_value("Company", appointment_doc.company, "cost_center")
+	item.rate = flt(registration_context.get("registration_fee"))
+	item.amount = flt(registration_context.get("registration_fee"))
+	item.qty = 1
+	item.reference_dt = "Patient"
+	item.reference_dn = appointment_doc.patient
+	return item
+
+
+def get_registration_fee_context(appointment_doc):
+	settings = get_registration_fee_settings()
+	if not settings.get("include_registration_fee"):
+		return {"apply_registration_fee": False, "registration_fee": 0, "registration_item": None}
+
+	if not settings.get("reg_item") or not flt(settings.get("reg_fee")):
+		return {"apply_registration_fee": False, "registration_fee": 0, "registration_item": None}
+
+	is_new_patient = check_is_new_patient_by_invoice(appointment_doc.patient)
+	if not is_new_patient:
+		return {"apply_registration_fee": False, "registration_fee": 0, "registration_item": None}
+
+	return {
+		"apply_registration_fee": True,
+		"registration_fee": flt(settings.get("reg_fee")),
+		"registration_item": settings.get("reg_item"),
+	}
+
+
+def get_registration_fee_settings():
+	settings = {"include_registration_fee": 0, "reg_item": None, "reg_fee": 0}
+	try:
+		settings["include_registration_fee"] = cint(
+			frappe.db.get_single_value("Healthcare Settings", "include_registration_fee")
+		)
+		settings["reg_item"] = frappe.db.get_single_value("Healthcare Settings", "reg_item")
+		settings["reg_fee"] = flt(frappe.db.get_single_value("Healthcare Settings", "reg_fee"))
+	except Exception:
+		# Custom fields may not exist in all sites.
+		return {"include_registration_fee": 0, "reg_item": None, "reg_fee": 0}
+	return settings
+
+
+def check_is_new_patient_by_invoice(patient):
+	patient_name, mobile = frappe.db.get_value("Patient", patient, ["patient_name", "mobile"])
+	patient_name = patient_name or ""
+	mobile = mobile or ""
+
+	match_conditions = ["si.patient = %(patient)s"]
+	if patient_name and mobile:
+		match_conditions.append("(p.patient_name = %(patient_name)s and ifnull(p.mobile, '') = %(mobile)s)")
+
+	has_submitted_invoice = frappe.db.sql(
+		f"""
+		SELECT si.name
+		FROM `tabSales Invoice` si
+		LEFT JOIN `tabPatient` p ON p.name = si.patient
+		WHERE si.docstatus = 1
+			AND ({' OR '.join(match_conditions)})
+		LIMIT 1
+		""",
+		{"patient": patient, "patient_name": patient_name, "mobile": mobile},
+	)
+	return not bool(has_submitted_invoice)
+
 def cancel_appointment(appointment_id):
 	appointment = frappe.get_doc("Patient Appointment", appointment_id)
 
@@ -674,7 +758,20 @@ def cancel_appointment(appointment_id):
 
 def cancel_sales_invoice(sales_invoice):
 	if frappe.db.get_single_value("Healthcare Settings", "show_payment_popup"):
-		if len(sales_invoice.items) == 1:
+		has_appointment_reference_item = any(
+			item.reference_dt == "Patient Appointment" and item.reference_dn == sales_invoice.appointment
+			for item in sales_invoice.items
+		)
+		has_other_references = any(
+			(item.reference_dt or item.reference_dn)
+			and not (
+				(item.reference_dt == "Patient Appointment" and item.reference_dn == sales_invoice.appointment)
+				or (item.reference_dt == "Patient" and item.reference_dn == sales_invoice.patient)
+			)
+			for item in sales_invoice.items
+		)
+
+		if has_appointment_reference_item and not has_other_references:
 			if sales_invoice.docstatus.is_submitted():
 				sales_invoice.cancel()
 			return True

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -694,24 +694,12 @@ def get_registration_fee_settings():
 
 
 def check_is_new_patient_by_invoice(patient):
-	patient_name, mobile = frappe.db.get_value("Patient", patient, ["patient_name", "mobile"])
-	patient_name = patient_name or ""
-	mobile = mobile or ""
-
-	match_conditions = ["si.patient = %(patient)s"]
-	if patient_name and mobile:
-		match_conditions.append("(p.patient_name = %(patient_name)s and ifnull(p.mobile, '') = %(mobile)s)")
-
-	has_submitted_invoice = frappe.db.sql(
-		f"""
-		SELECT si.name
-		FROM `tabSales Invoice` si
-		LEFT JOIN `tabPatient` p ON p.name = si.patient
-		WHERE si.docstatus = 1
-			AND ({' OR '.join(match_conditions)})
-		LIMIT 1
-		""",
-		{"patient": patient, "patient_name": patient_name, "mobile": mobile},
+	has_submitted_invoice = frappe.db.exists(
+		"Sales Invoice",
+		{
+			"docstatus": 1,
+			"patient": patient,
+		},
 	)
 	return not bool(has_submitted_invoice)
 

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -545,7 +545,6 @@ def invoice_appointment(appointment_name, discount_percentage=0, discount_amount
 	update_fee_validity(appointment_doc)
 
 
-
 @frappe.whitelist()
 def get_registration_fee_details(appointment_name):
 	appointment_doc = frappe.get_doc("Patient Appointment", appointment_name)
@@ -554,6 +553,7 @@ def get_registration_fee_details(appointment_name):
 		"apply_registration_fee": registration_context.get("apply_registration_fee"),
 		"registration_fee": registration_context.get("registration_fee"),
 	}
+
 
 def create_sales_invoice(appointment_doc, discount_percentage=0, discount_amount=0):
 	sales_invoice = frappe.new_doc("Sales Invoice")
@@ -578,9 +578,11 @@ def create_sales_invoice(appointment_doc, discount_percentage=0, discount_amount
 	if flt(discount_percentage):
 		sales_invoice.additional_discount_percentage = flt(discount_percentage)
 		paid_amount = paid_amount - (paid_amount * (flt(discount_percentage) / 100))
+		paid_amount = max(0, paid_amount)
 	if flt(discount_amount):
 		sales_invoice.discount_amount = flt(discount_amount)
 		paid_amount = paid_amount - flt(discount_amount)
+		paid_amount = max(0, paid_amount)
 
 	# Add payments if payment details are supplied else proceed to create invoice as Unpaid
 	if appointment_doc.mode_of_payment and paid_amount:
@@ -646,7 +648,6 @@ def get_appointment_item(appointment_doc, item):
 	return item
 
 
-
 def get_registration_item(appointment_doc, item, registration_context):
 	item.item_code = registration_context.get("registration_item")
 	item.description = _("Registration Charges")
@@ -705,6 +706,7 @@ def check_is_new_patient_by_invoice(patient):
 		},
 	)
 	return not bool(has_submitted_invoice)
+
 
 def cancel_appointment(appointment_id):
 	appointment = frappe.get_doc("Patient Appointment", appointment_id)
@@ -769,9 +771,7 @@ def cancel_sales_invoice(sales_invoice, appointment_name=None):
 		for item in sales_invoice.items
 	)
 	has_other_references = any(
-		not (
-			item.reference_dt == "Patient Appointment" and item.reference_dn == appointment_name
-		)
+		not (item.reference_dt == "Patient Appointment" and item.reference_dn == appointment_name)
 		for item in sales_invoice.items
 	)
 

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -771,7 +771,10 @@ def cancel_sales_invoice(sales_invoice, appointment_name=None):
 		for item in sales_invoice.items
 	)
 	has_other_references = any(
-		not (item.reference_dt == "Patient Appointment" and item.reference_dn == appointment_name)
+		not (
+			(item.reference_dt == "Patient Appointment" and item.reference_dn == appointment_name)
+			or (item.reference_dt == "Patient" and item.reference_dn == sales_invoice.patient)
+		)
 		for item in sales_invoice.items
 	)
 

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -665,7 +665,8 @@ def get_registration_fee_context(appointment_doc):
 	if not settings.get("include_registration_fee"):
 		return {"apply_registration_fee": False, "registration_fee": 0, "registration_item": None}
 
-	if not settings.get("reg_item") or not flt(settings.get("reg_fee")):
+	reg_fee = flt(settings.get("reg_fee"))
+	if not settings.get("reg_item") or reg_fee <= 0:
 		return {"apply_registration_fee": False, "registration_fee": 0, "registration_item": None}
 
 	is_new_patient = check_is_new_patient_by_invoice(appointment_doc.patient)
@@ -674,22 +675,24 @@ def get_registration_fee_context(appointment_doc):
 
 	return {
 		"apply_registration_fee": True,
-		"registration_fee": flt(settings.get("reg_fee")),
+		"registration_fee": reg_fee,
 		"registration_item": settings.get("reg_item"),
 	}
 
 
 def get_registration_fee_settings():
 	settings = {"include_registration_fee": 0, "reg_item": None, "reg_fee": 0}
-	try:
-		settings["include_registration_fee"] = cint(
-			frappe.db.get_single_value("Healthcare Settings", "include_registration_fee")
-		)
-		settings["reg_item"] = frappe.db.get_single_value("Healthcare Settings", "reg_item")
-		settings["reg_fee"] = flt(frappe.db.get_single_value("Healthcare Settings", "reg_fee"))
-	except Exception:
+	meta = frappe.get_meta("Healthcare Settings")
+	required_fields = ("include_registration_fee", "reg_item", "reg_fee")
+	if not all(meta.has_field(fieldname) for fieldname in required_fields):
 		# Custom fields may not exist in all sites.
-		return {"include_registration_fee": 0, "reg_item": None, "reg_fee": 0}
+		return settings
+
+	settings["include_registration_fee"] = cint(
+		frappe.db.get_single_value("Healthcare Settings", "include_registration_fee")
+	)
+	settings["reg_item"] = frappe.db.get_single_value("Healthcare Settings", "reg_item")
+	settings["reg_fee"] = flt(frappe.db.get_single_value("Healthcare Settings", "reg_fee"))
 	return settings
 
 
@@ -718,7 +721,7 @@ def cancel_appointment(appointment_id):
 
 	if appointment.invoiced:
 		sales_invoice = check_sales_invoice_exists(appointment)
-		if sales_invoice and cancel_sales_invoice(sales_invoice):
+		if sales_invoice and cancel_sales_invoice(sales_invoice, appointment.name):
 			msg = _("Appointment {0} and Sales Invoice {1} cancelled").format(
 				appointment.name, sales_invoice.name
 			)
@@ -744,25 +747,38 @@ def cancel_appointment(appointment_id):
 	frappe.msgprint(msg)
 
 
-def cancel_sales_invoice(sales_invoice):
-	if frappe.db.get_single_value("Healthcare Settings", "show_payment_popup"):
-		has_appointment_reference_item = any(
-			item.reference_dt == "Patient Appointment" and item.reference_dn == sales_invoice.appointment
-			for item in sales_invoice.items
-		)
-		has_other_references = any(
-			(item.reference_dt or item.reference_dn)
-			and not (
-				(item.reference_dt == "Patient Appointment" and item.reference_dn == sales_invoice.appointment)
-				or (item.reference_dt == "Patient" and item.reference_dn == sales_invoice.patient)
-			)
-			for item in sales_invoice.items
+def cancel_sales_invoice(sales_invoice, appointment_name=None):
+	if not frappe.db.get_single_value("Healthcare Settings", "show_payment_popup"):
+		return False
+
+	if not appointment_name:
+		appointment_name = next(
+			(
+				item.reference_dn
+				for item in sales_invoice.items
+				if item.reference_dt == "Patient Appointment" and item.reference_dn
+			),
+			None,
 		)
 
-		if has_appointment_reference_item and not has_other_references:
-			if sales_invoice.docstatus.is_submitted():
-				sales_invoice.cancel()
-			return True
+	if not appointment_name:
+		return False
+
+	has_appointment_reference_item = any(
+		item.reference_dt == "Patient Appointment" and item.reference_dn == appointment_name
+		for item in sales_invoice.items
+	)
+	has_other_references = any(
+		not (
+			item.reference_dt == "Patient Appointment" and item.reference_dn == appointment_name
+		)
+		for item in sales_invoice.items
+	)
+
+	if has_appointment_reference_item and not has_other_references:
+		if sales_invoice.docstatus.is_submitted():
+			sales_invoice.cancel()
+		return True
 	return False
 
 


### PR DESCRIPTION
ERPNext Healthcare/Marley Healthcare already provides a “Collect Registration Fee” setting. When enabled, the system expects the registration fee to be collected immediately for new patients. However, in many hospitals appointments are often booked over phone calls, and patients typically pay only when they arrive at the hospital, which can create issues during appointment creation as disabled patients are not listed in dropdown.

This change improves the billing flow by combining the registration fee with the consultation fee for new patients when the setting "Include Registration Fee with Consultaion Fee" is enabled. If the patient has no submitted Sales Invoice (new patient), the registration fee is included in the payable amount shown in the payment popup and reflected during invoice creation.

Discounts are calculated on the total charge (consultation + registration fee) so that the payment popup totals and invoice totals remain consistent.

This approach supports hospitals that prefer combined billing for consultation and registration fees.

no-docs