### PR TITLE
Feat: Auto-Generate Token Number for Queue-Based Patient Appointments

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -68,6 +68,7 @@
   "section_break_3",
   "appointment_based_on_check_in",
   "position_in_queue",
+  "token_number",
   "column_break_wicc",
   "reminded",
   "appointment_notes_section",
@@ -556,6 +557,15 @@
    "read_only": 1,
    "report_hide": 1,
    "search_index": 1
+  },
+  {
+   "depends_on": "eval:doc.appointment_based_on_check_in",
+   "description": "Token number assigned when the appointment is booked for queue-based consultations. Visible only when Appointment Based on Check-In is checked.",
+   "fieldname": "token_number",
+   "fieldtype": "Int",
+   "label": "Token Number",
+   "non_negative": 1,
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -576,7 +586,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2025-12-25 09:36:33.925751",
+ "modified": "2026-03-09 15:01:42.819402",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Patient Appointment",

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -58,6 +58,7 @@ class PatientAppointment(Document):
 		self.set_status()
 		self.set_title()
 		self.update_event()
+		self.set_token_number()
 		self.set_position_in_queue()
 
 	def on_update(self):
@@ -459,6 +460,45 @@ class PatientAppointment(Document):
 				event_doc.save(ignore_permissions=True)
 				event_doc.reload()
 				self.google_meet_link = event_doc.google_meet_link
+
+	def set_token_number(self):
+		from frappe.query_builder.functions import Max
+
+		if not self.meta.has_field("token_number"):
+			return
+
+		if not self.appointment_based_on_check_in or self.token_number:
+			return
+
+		if not self.appointment_date:
+			return
+
+		appointment = frappe.qb.DocType("Patient Appointment")
+		query = (
+			frappe.qb.from_(appointment)
+			.select(Max(appointment.token_number).as_("max_token"))
+			.where(
+				(appointment.appointment_based_on_check_in == 1)
+				& (appointment.name != self.name)
+				& (appointment.appointment_date == self.appointment_date)
+			)
+		)
+
+		if self.appointment_for == "Practitioner":
+			query = query.where(
+				(appointment.practitioner == self.practitioner)
+				& (appointment.appointment_time == self.appointment_time)
+				& (appointment.service_unit == self.service_unit)
+			)
+		else:
+			if self.service_unit:
+				query = query.where(appointment.service_unit == self.service_unit)
+			if self.department:
+				query = query.where(appointment.department == self.department)
+
+		result = query.run(as_dict=True)
+		max_token = result[0]["max_token"] if result and result[0].get("max_token") else 0
+		self.token_number = max_token + 1
 
 	def set_position_in_queue(self):
 		from frappe.query_builder.functions import Max

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -3,6 +3,7 @@
 
 
 import datetime
+import hashlib
 import json
 from typing import Optional
 
@@ -461,6 +462,32 @@ class PatientAppointment(Document):
 				event_doc.reload()
 				self.google_meet_link = event_doc.google_meet_link
 
+	def _get_token_lock_name(self):
+		scope_parts = [
+			str(self.appointment_date or ""),
+			str(self.appointment_for or ""),
+			str(self.practitioner or ""),
+			str(self.appointment_time or ""),
+			str(self.service_unit or ""),
+			str(self.department or ""),
+		]
+		raw_key = "|".join(scope_parts)
+		key_hash = hashlib.sha1(raw_key.encode()).hexdigest()
+		return f"patient_appt_token_{key_hash}"
+
+	def _acquire_token_lock(self, lock_name, timeout=10):
+		if frappe.db.db_type == "postgres":
+			# Transaction-scoped advisory lock in PostgreSQL.
+			frappe.db.sql("SELECT pg_advisory_xact_lock(hashtext(%s))", (lock_name,))
+			return True
+
+		locked = frappe.db.sql("SELECT GET_LOCK(%s, %s)", (lock_name, timeout))
+		return bool(locked and locked[0] and locked[0][0] == 1)
+
+	def _release_token_lock(self, lock_name):
+		if frappe.db.db_type != "postgres":
+			frappe.db.sql("SELECT RELEASE_LOCK(%s)", (lock_name,))
+
 	def set_token_number(self):
 		from frappe.query_builder.functions import Max
 
@@ -473,32 +500,39 @@ class PatientAppointment(Document):
 		if not self.appointment_date:
 			return
 
-		appointment = frappe.qb.DocType("Patient Appointment")
-		query = (
-			frappe.qb.from_(appointment)
-			.select(Max(appointment.token_number).as_("max_token"))
-			.where(
-				(appointment.appointment_based_on_check_in == 1)
-				& (appointment.name != self.name)
-				& (appointment.appointment_date == self.appointment_date)
-			)
-		)
+		lock_name = self._get_token_lock_name()
+		if not self._acquire_token_lock(lock_name):
+			frappe.throw(_("Unable to assign token number right now. Please try again."))
 
-		if self.appointment_for == "Practitioner":
-			query = query.where(
-				(appointment.practitioner == self.practitioner)
-				& (appointment.appointment_time == self.appointment_time)
-				& (appointment.service_unit == self.service_unit)
+		try:
+			appointment = frappe.qb.DocType("Patient Appointment")
+			query = (
+				frappe.qb.from_(appointment)
+				.select(Max(appointment.token_number).as_("max_token"))
+				.where(
+					(appointment.appointment_based_on_check_in == 1)
+					& (appointment.name != self.name)
+					& (appointment.appointment_date == self.appointment_date)
+				)
 			)
-		else:
-			if self.service_unit:
-				query = query.where(appointment.service_unit == self.service_unit)
-			if self.department:
-				query = query.where(appointment.department == self.department)
 
-		result = query.run(as_dict=True)
-		max_token = result[0]["max_token"] if result and result[0].get("max_token") else 0
-		self.token_number = max_token + 1
+			if self.appointment_for == "Practitioner":
+				query = query.where(
+					(appointment.practitioner == self.practitioner)
+					& (appointment.appointment_time == self.appointment_time)
+					& (appointment.service_unit == self.service_unit)
+				)
+			else:
+				if self.service_unit:
+					query = query.where(appointment.service_unit == self.service_unit)
+				if self.department:
+					query = query.where(appointment.department == self.department)
+
+			result = query.run(as_dict=True)
+			max_token = result[0]["max_token"] if result and result[0].get("max_token") else 0
+			self.token_number = max_token + 1
+		finally:
+			self._release_token_lock(lock_name)
 
 	def set_position_in_queue(self):
 		from frappe.query_builder.functions import Max

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -3,8 +3,8 @@
 
 
 import datetime
-import hashlib
 import json
+import zlib
 from typing import Optional
 
 import frappe
@@ -463,16 +463,20 @@ class PatientAppointment(Document):
 				self.google_meet_link = event_doc.google_meet_link
 
 	def _get_token_lock_name(self):
-		scope_parts = [
-			str(self.appointment_date or ""),
-			str(self.appointment_for or ""),
-			str(self.practitioner or ""),
-			str(self.appointment_time or ""),
-			str(self.service_unit or ""),
-			str(self.department or ""),
-		]
+		scope_parts = [str(self.appointment_date or ""), str(self.appointment_for or "")]
+		if self.appointment_for == "Practitioner":
+			scope_parts.extend(
+				[
+					str(self.practitioner or ""),
+					str(self.appointment_time or ""),
+					str(self.service_unit or ""),
+				]
+			)
+		else:
+			scope_parts.extend([str(self.service_unit or ""), str(self.department or "")])
+
 		raw_key = "|".join(scope_parts)
-		key_hash = hashlib.sha1(raw_key.encode()).hexdigest()
+		key_hash = f"{zlib.adler32(raw_key.encode()) & 0xFFFFFFFF:08x}"
 		return f"patient_appt_token_{key_hash}"
 
 	def _acquire_token_lock(self, lock_name, timeout=10):


### PR DESCRIPTION
Previously, in Patient Appointment, there was no field to store a token number for queue-based consultations. When Appointment Based on Check-In was enabled, the system only generated position_in_queue after the Check-In button was pressed.

Because of this, the front desk/receptionist could not issue a token number at the time of booking, which is a common workflow in hospitals and clinics where patients are given a token immediately when the appointment is created.

This PR adds token support for queue-based Patient Appointments.

Changes Introduced:-
1.A new read-only field has been introduced on Patient Appointment:
         token_number (Int, non-negative, read-only)
         Visible only when appointment_based_on_check_in is enabled (depends_on condition)

Behavior Added:-
1.Token number is auto-generated at booking/save time (not on Check-In)
2.Applies only for queue-based appointments (appointment_based_on_check_in = 1)
3.Scope logic aligns with existing queue scope patterns used for appointment ordering
4.Existing position_in_queue logic remains unchanged

Example Scenario
Receptionist books appointments for a practitioner who uses queue-based consultation.

At booking/taking appointment:
Patient A → Token 1
Patient B → Token 2
Patient C → Token 3

no-docs