### PR TITLE
fix: use query builder in get_leave_from to prevent sql injection

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -641,6 +641,7 @@ def get_leave_from(
 	doctype: str | None, txt: str, searchfield: str | None, start: int, page_len: int, filters: dict
 ):
 	docname = filters["docname"]
+	frappe.has_permission("Inpatient Record", "read", docname, throw=True)
 
 	io = frappe.qb.DocType("Inpatient Occupancy")
 
@@ -648,6 +649,7 @@ def get_leave_from(
 		frappe.qb.from_(io)
 		.select(io.service_unit)
 		.where(io.parent == docname)
+		.where(io.parenttype == "Inpatient Record")
 		.where(io.parentfield == "inpatient_occupancies")
 		.where(io.left != 1)
 	)

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -7,7 +7,6 @@ from math import floor
 
 import frappe
 from frappe import _
-from frappe.desk.reportview import get_match_cond
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import (
@@ -641,15 +640,20 @@ def patient_leave_service_unit(inpatient_record, check_out, leave_from):
 def get_leave_from(doctype, txt, searchfield, start, page_len, filters):
 	docname = filters["docname"]
 
-	query = """select io.service_unit
-		from `tabInpatient Occupancy` io, `tabInpatient Record` ir
-		where io.parent = '{docname}' and io.parentfield = 'inpatient_occupancies'
-		and io.left!=1 and io.parent = ir.name"""
+	io = frappe.qb.DocType("Inpatient Occupancy")
 
-	return frappe.db.sql(
-		query.format(**{"docname": docname, "searchfield": searchfield, "mcond": get_match_cond(doctype)}),
-		{"txt": f"%{txt}%", "_txt": txt.replace("%", ""), "start": start, "page_len": page_len},
+	query = (
+		frappe.qb.from_(io)
+		.select(io.service_unit)
+		.where(io.parent == docname)
+		.where(io.parentfield == "inpatient_occupancies")
+		.where(io.left != 1)
 	)
+
+	if txt:
+		query = query.where(io.service_unit.like(f"%{txt}%"))
+
+	return query.limit(page_len).offset(start).run()
 
 
 def is_service_unit_billable(service_unit):

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -637,7 +637,9 @@ def patient_leave_service_unit(inpatient_record, check_out, leave_from):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_leave_from(doctype: str | None, txt: str, searchfield: str | None, start: int, page_len: int, filters: dict):
+def get_leave_from(
+	doctype: str | None, txt: str, searchfield: str | None, start: int, page_len: int, filters: dict
+):
 	docname = filters["docname"]
 
 	io = frappe.qb.DocType("Inpatient Occupancy")

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -637,7 +637,7 @@ def patient_leave_service_unit(inpatient_record, check_out, leave_from):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_leave_from(doctype, txt, searchfield, start, page_len, filters):
+def get_leave_from(doctype: str | None, txt: str, searchfield: str | None, start: int, page_len: int, filters: dict):
 	docname = filters["docname"]
 
 	io = frappe.qb.DocType("Inpatient Occupancy")


### PR DESCRIPTION
**Problem**
 `get_leave_from` uses `.format()` to put user input directly into SQL. Any logged-in user can read any table in the database through this endpoint.

**For example,** using error-based extraction:            
 ```
 docname = "' AND EXTRACTVALUE(1, CONCAT(0x7e, (SELECT salary FROM tabEmployee LIMIT 1)))
  --" 
```                                                                                     
   
  This leaks values in the error message. Works for any table — not just healthcare,       
  but **HRMS**, **ERPNext**, or any app sharing the same database.