### PR TITLE
fix: use get_value for patient link in healthcare invoice

### DIFF
--- a/healthcare/public/js/sales_invoice.js
+++ b/healthcare/public/js/sales_invoice.js
@@ -151,7 +151,7 @@ var get_healthcare_services_to_invoice = function (frm, link_customer) {
 		patient: frm.doc.patient,
 	});
 	dialog.fields_dict["patient"].df.onchange = () => {
-		var patient = dialog.fields_dict.patient.input.value;
+		var patient = dialog.get_value("patient");
 		if (patient && patient != selected_patient) {
 			selected_patient = patient;
 			var method =


### PR DESCRIPTION
**Closes:** #919
                                                                                                             
**Problem**

When **Show Title in Link Fields** is enabled for the Patient doctype, `dialog.fields_dict.patient.input.value` returns the patient's display name instead of the document ID. The server then can't find the patient and returns error.

**Fix**

Use `dialog.get_value("patient")` which always returns the document ID regardless of the "Show Title in Link Fields" setting.                                                     
                                                   