### PR TITLE
fix: Reload Diagnostic Report after workflow action to resolve unsave…

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.js
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.js
@@ -12,7 +12,7 @@ frappe.ui.form.on("Diagnostic Report", {
 	},
 	before_save: function (frm) {
 		if (!frm.is_new() && frm.is_dirty()) {
-			this.diagnostic_report.save_action("save");
+			return this.diagnostic_report.save_action("save");
 		}
 	},
 	after_workflow_action: function (frm) {
@@ -20,6 +20,9 @@ frappe.ui.form.on("Diagnostic Report", {
 			method: "healthcare.healthcare.doctype.diagnostic_report.diagnostic_report.set_observation_status",
 			args: {
 				docname: frm.doc.name,
+			},
+			callback: function () {
+				frm.reload_doc();
 			},
 		});
 	},

--- a/healthcare/public/js/diagnostic_report_controller.js
+++ b/healthcare/public/js/diagnostic_report_controller.js
@@ -69,7 +69,7 @@ healthcare.Diagnostic.DiagnosticReport = class DiagnosticReport {
 	save_action(func) {
 		var me = this;
 		if (func == "save") {
-			frappe.call({
+			return frappe.call({
 				method: "healthcare.healthcare.doctype.observation.observation.record_observation_result",
 				args: {
 					values: this.result,

--- a/healthcare/public/js/observation_widget.js
+++ b/healthcare/public/js/observation_widget.js
@@ -207,8 +207,11 @@ healthcare.ObservationWidget = class {
 					options: options,
 					read_only: 1 ? obs_data.status == "Approved" : 0,
 					change: s => {
-						me.frm.dirty();
-						me.set_result_n_name(obs_data.name);
+						let current_val = me[obs_data.name].get_value("result");
+						if ((current_val || "") != (default_input || "")) {
+							me.frm.dirty();
+							me.set_result_n_name(obs_data.name);
+						}
 					},
 					default: default_input,
 					hidden: 1 ? obs_data.observation_category == "Imaging" : 0,


### PR DESCRIPTION
After performing a workflow action (e.g., Approve) on Diagnostic Report,
the backend updates observation status via set_observation_status, but
the form remains in a dirty (unsaved) state in the UI.

This causes the "Not Saved" indicator to appear even though the document
is already updated and shows correct status in list view.

Added frm.reload_doc() after successful workflow action to sync the form
state with backend and clear the false unsaved state.

Also added a safety check before calling save_action in before_save.