### PR TITLE
fix: diagnostic report status count for imaging observations

### DIFF
--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -186,8 +186,7 @@ def aggregate_and_return_observation_data(observations):
 
 	for obs in observations:
 		if not obs.get("has_component"):
-			if obs.get("permitted_data_type"):
-				obs_length += 1
+			obs_length += 1
 
 			if obs.get("permitted_data_type") == "Select" and obs.get("options"):
 				obs["options_list"] = obs.get("options").split("\n")
@@ -234,8 +233,7 @@ def return_child_observation_data_as_dict(child_observations, obs, obs_length=0)
 			if not grand_dict.get("obs_approved", False):
 				all_children_approved = False
 		else:
-			if child.get("permitted_data_type"):
-				obs_length += 1
+			obs_length += 1
 			if child.get("permitted_data_type") == "Select" and child.get("options"):
 				child["options_list"] = child.get("options").split("\n")
 			if child.get("specimen"):


### PR DESCRIPTION
PR Description

Issue:-
In diagnostic reports, imaging observations could be approved using result_text and result_interpretation even when permitted_data_type was empty. The diagnostic report status calculation was only counting observations that had permitted_data_type, which caused imaging observations to be excluded from the total observation count.

This led to incorrect status transitions:
After Approve: approved count became 1 while total count stayed 0, so the report showed Partially Approved instead of Approved.
After Reject: approved count became 0 while total count stayed 0, so the report showed Approved instead of open.

Fix Applied:-
Updated the diagnostic report observation counting logic in observation.py to count all leaf observations, not only those with permitted_data_type.

Changed areas:
1)aggregate_and_return_observation_data
2)return_child_observation_data_as_dict
