### PR TITLE
fix: only nongroup Customer Groups are allowed in upstream Customer

### DIFF
--- a/healthcare/healthcare/doctype/patient/patient.json
+++ b/healthcare/healthcare/doctype/patient/patient.json
@@ -394,6 +394,7 @@
    "fieldname": "customer_group",
    "fieldtype": "Link",
    "label": "Customer Group",
+   "link_filters": "[[\"Customer Group\",\"is_group\",\"=\",0]]",
    "options": "Customer Group"
   },
   {
@@ -612,7 +613,7 @@
   }
  ],
  "max_attachments": 50,
- "modified": "2025-12-25 09:36:34.528457",
+ "modified": "2026-04-18 12:02:00.596085",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Patient",

--- a/healthcare/healthcare/doctype/patient/patient.py
+++ b/healthcare/healthcare/doctype/patient/patient.py
@@ -80,7 +80,7 @@ class Patient(Document):
 		if not self.customer_group:
 			self.customer_group = frappe.db.get_single_value(
 				"Selling Settings", "customer_group"
-			) or get_root_of("Customer Group")
+			) or frappe.db.exists("Customer Group", "Individual")
 		if not self.territory:
 			self.territory = frappe.db.get_single_value("Selling Settings", "territory") or get_root_of(
 				"Territory"


### PR DESCRIPTION
- apply link filter
- set default to "Individual" for patients