### PR TITLE
feat: add Death Record doctype with patient and death details fields

### DIFF
--- a/healthcare/healthcare/doctype/death_record/death_record.js
+++ b/healthcare/healthcare/doctype/death_record/death_record.js
@@ -7,30 +7,29 @@
 // 	},
 // });
 frappe.ui.form.on("Death Record", {
-    patient(frm) {
-        // Clear dependent fields when patient changes
-        frm.set_value("inpatient_record", null);
-        frm.set_value("patient_encounter", null);
-    },
+	patient(frm) {
+		// Clear dependent fields when patient changes
+		frm.set_value("inpatient_record", null);
+		frm.set_value("patient_encounter", null);
+	},
 
-    onload(frm) {
-        // Filter Inpatient Record
-        frm.set_query("inpatient_record", function() {
-            return {
-                filters: {
-                    "patient": frm.doc.patient
-                }
-            };
-        });
+	onload(frm) {
+		// Filter Inpatient Record
+		frm.set_query("inpatient_record", function () {
+			return {
+				filters: {
+					patient: frm.doc.patient,
+				},
+			};
+		});
 
-        // Filter Patient Encounter
-        frm.set_query("patient_encounter", function() {
-            return {
-                filters: {
-                    "patient": frm.doc.patient
-                }
-            };
-        });
-    }
-
+		// Filter Patient Encounter
+		frm.set_query("patient_encounter", function () {
+			return {
+				filters: {
+					patient: frm.doc.patient,
+				},
+			};
+		});
+	},
 });

--- a/healthcare/healthcare/doctype/death_record/death_record.js
+++ b/healthcare/healthcare/doctype/death_record/death_record.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2026, earthians Health Informatics Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Death Record", {
+// 	refresh(frm) {
+
+// 	},
+// });
+frappe.ui.form.on("Death Record", {
+    patient(frm) {
+        // Clear dependent fields when patient changes
+        frm.set_value("inpatient_record", null);
+        frm.set_value("patient_encounter", null);
+    },
+
+    onload(frm) {
+        // Filter Inpatient Record
+        frm.set_query("inpatient_record", function() {
+            return {
+                filters: {
+                    "patient": frm.doc.patient
+                }
+            };
+        });
+
+        // Filter Patient Encounter
+        frm.set_query("patient_encounter", function() {
+            return {
+                filters: {
+                    "patient": frm.doc.patient
+                }
+            };
+        });
+    }
+
+});

--- a/healthcare/healthcare/doctype/death_record/death_record.json
+++ b/healthcare/healthcare/doctype/death_record/death_record.json
@@ -1,0 +1,229 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "naming_series:",
+ "creation": "2026-04-24 10:20:41.873216",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_lp2e",
+  "amended_from",
+  "naming_series",
+  "section_patient_details",
+  "patient",
+  "patient_name",
+  "inpatient_record",
+  "patient_encounter",
+  "company",
+  "section_death_details",
+  "date_of_death",
+  "time_of_death",
+  "place_of_death",
+  "practitioner",
+  "medical_department",
+  "column_break_unnq",
+  "death_facility",
+  "death_type",
+  "manner_of_death",
+  "section_cause_of_death",
+  "immediate_cause_of_death",
+  "underlying_cause_of_death",
+  "other_conditions",
+  "section_informant",
+  "informant_name",
+  "informant_relation",
+  "informant_contact"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_lp2e",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Death Record",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Naming Series",
+   "options": "HLC-DR-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_patient_details",
+   "fieldtype": "Section Break",
+   "label": "Patient Details"
+  },
+  {
+   "fieldname": "patient",
+   "fieldtype": "Link",
+   "label": "Patient",
+   "options": "Patient",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "patient.patient_name",
+   "fieldname": "patient_name",
+   "fieldtype": "Data",
+   "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "inpatient_record",
+   "fieldtype": "Link",
+   "label": "Inpatient Record",
+   "options": "Inpatient Record"
+  },
+  {
+   "fieldname": "patient_encounter",
+   "fieldtype": "Link",
+   "label": "Patient Encounter",
+   "options": "Patient Encounter"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company"
+  },
+  {
+   "fieldname": "section_death_details",
+   "fieldtype": "Section Break",
+   "label": "Death Details"
+  },
+  {
+   "fieldname": "date_of_death",
+   "fieldtype": "Date",
+   "label": "Date of Death",
+   "reqd": 1
+  },
+  {
+   "fieldname": "time_of_death",
+   "fieldtype": "Time",
+   "label": "Time of Death"
+  },
+  {
+   "fieldname": "place_of_death",
+   "fieldtype": "Data",
+   "label": "Place of Death"
+  },
+  {
+   "fieldname": "death_facility",
+   "fieldtype": "Link",
+   "label": "Death Facility",
+   "options": "Healthcare Service Unit"
+  },
+  {
+   "fieldname": "death_type",
+   "fieldtype": "Select",
+   "label": "Death Type",
+   "options": "\nNatural\nAccidental\nBrought Dead\nMedico-Legal\nUnknown"
+  },
+  {
+   "fieldname": "manner_of_death",
+   "fieldtype": "Select",
+   "label": "Manner of Death",
+   "options": "\nNatural\nAccident\nSuicide\nHomicide\nUnknown"
+  },
+  {
+   "fieldname": "section_cause_of_death",
+   "fieldtype": "Section Break",
+   "label": "Cause of Death"
+  },
+  {
+   "fieldname": "immediate_cause_of_death",
+   "fieldtype": "Small Text",
+   "label": "Immediate Cause of Death",
+   "reqd": 1
+  },
+  {
+   "fieldname": "underlying_cause_of_death",
+   "fieldtype": "Small Text",
+   "label": "Underlying Cause of Death"
+  },
+  {
+   "fieldname": "other_conditions",
+   "fieldtype": "Small Text",
+   "label": "Other Conditions"
+  },
+  {
+   "fieldname": "practitioner",
+   "fieldtype": "Link",
+   "label": "Healthcare Practitioner",
+   "options": "Healthcare Practitioner",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "practitioner.department",
+   "fieldname": "medical_department",
+   "fieldtype": "Link",
+   "label": "Medical Department",
+   "options": "Medical Department"
+  },
+  {
+   "fieldname": "column_break_unnq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_informant",
+   "fieldtype": "Section Break",
+   "label": "Informant Details"
+  },
+  {
+   "fieldname": "informant_name",
+   "fieldtype": "Data",
+   "label": "Informant Name"
+  },
+  {
+   "fieldname": "informant_relation",
+   "fieldtype": "Data",
+   "label": "Informant Relation"
+  },
+  {
+   "fieldname": "informant_contact",
+   "fieldtype": "Data",
+   "label": "Informant Contact"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2026-04-24 10:41:01.229183",
+ "modified_by": "Administrator",
+ "module": "Healthcare",
+ "name": "Death Record",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "select": 1,
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/healthcare/healthcare/doctype/death_record/death_record.py
+++ b/healthcare/healthcare/doctype/death_record/death_record.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, earthians Health Informatics Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class DeathRecord(Document):
+	pass

--- a/healthcare/healthcare/doctype/death_record/test_death_record.py
+++ b/healthcare/healthcare/doctype/death_record/test_death_record.py
@@ -4,7 +4,6 @@
 # import frappe
 from frappe.tests import IntegrationTestCase
 
-
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list

--- a/healthcare/healthcare/doctype/death_record/test_death_record.py
+++ b/healthcare/healthcare/doctype/death_record/test_death_record.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, earthians Health Informatics Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestDeathRecord(IntegrationTestCase):
+	"""
+	Integration tests for DeathRecord.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass


### PR DESCRIPTION
This PR adds the Death Record DocType in the Healthcare module.

1. The Death Record DocType uses the naming series HLC-DR-.YYYY.-.
2. The following sections are included in the DocType:
    - Patient Details: Captures patient-related information, including linked Inpatient Record and Patient Encounter details.
    - Death Details: Captures death-related information such as date of death, place of death, death type, and manner of death.
    - Cause of Death: Captures details related to the cause of death.
    - Informant Details: Captures informant information such as name, relation, and contact details.

<img width="1028" height="902" alt="image" src="https://github.com/user-attachments/assets/a468b749-c0e4-4245-89c9-6b02c67f7758" />

no-docs
