### PR TITLE
feat: Add ordered-by practitioner fields to Therapy Plan and populate them from Patient Encounter

### DIFF
--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.py
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.py
@@ -414,6 +414,8 @@ def create_therapy_plan(encounter):
 		doc.source_doc = encounter.doctype
 		doc.order_group = encounter.name
 		doc.company = encounter.company
+		doc.practitioner = encounter.practitioner
+		doc.practitioner_name = encounter.practitioner_name
 		for entry in encounter.therapies:
 			doc.append(
 				"therapy_plan_details",

--- a/healthcare/healthcare/doctype/therapy_plan/test_therapy_plan.py
+++ b/healthcare/healthcare/doctype/therapy_plan/test_therapy_plan.py
@@ -78,9 +78,7 @@ def create_therapy_plan(template=None, patient=None):
 	plan.start_date = getdate()
 	plan.company = "_Test Company"
 	plan.practitioner = practitioner
-	plan.practitioner_name = frappe.db.get_value(
-		"Healthcare Practitioner", practitioner, "practitioner_name"
-	)
+	plan.practitioner_name = frappe.db.get_value("Healthcare Practitioner", practitioner, "practitioner_name")
 
 	if template:
 		plan.therapy_plan_template = template

--- a/healthcare/healthcare/doctype/therapy_plan/test_therapy_plan.py
+++ b/healthcare/healthcare/doctype/therapy_plan/test_therapy_plan.py
@@ -72,10 +72,15 @@ def create_therapy_plan(template=None, patient=None):
 		patient = frappe.get_list("Patient", pluck="name")[0]
 
 	therapy_type = frappe.get_list("Therapy Type", pluck="name")[0]
+	practitioner = frappe.get_list("Healthcare Practitioner", pluck="name")[0]
 	plan = frappe.new_doc("Therapy Plan")
 	plan.patient = patient
 	plan.start_date = getdate()
 	plan.company = "_Test Company"
+	plan.practitioner = practitioner
+	plan.practitioner_name = frappe.db.get_value(
+		"Healthcare Practitioner", practitioner, "practitioner_name"
+	)
 
 	if template:
 		plan.therapy_plan_template = template

--- a/healthcare/healthcare/doctype/therapy_plan/therapy_plan.json
+++ b/healthcare/healthcare/doctype/therapy_plan/therapy_plan.json
@@ -24,7 +24,10 @@
   "total_sessions_completed",
   "more_information_section",
   "source_doc",
-  "order_group"
+  "order_group",
+  "column_break_vlgf",
+  "practitioner",
+  "practitioner_name"
  ],
  "fields": [
   {
@@ -151,6 +154,28 @@
    "no_copy": 1,
    "options": "source_doc",
    "read_only": 1
+  },
+  {
+   "fieldname": "practitioner",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Ordered By Practitioner",
+   "options": "Healthcare Practitioner",
+   "reqd": 1,
+   "search_index": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "column_break_vlgf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "practitioner.practitioner_name",
+   "fieldname": "practitioner_name",
+   "fieldtype": "Data",
+   "label": "Ordered By Practitioner Name",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -161,7 +186,7 @@
    "link_fieldname": "therapy_plan"
   }
  ],
- "modified": "2025-12-25 09:36:30.448853",
+ "modified": "2026-04-25 14:28:01.138405",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Therapy Plan",


### PR DESCRIPTION
This PR adds ordering practitioner details to Therapy Plan and ensures they are populated when a Therapy Plan is created from a Patient Encounter.

Changes:-
Added two new fields to Therapy Plan:
1)Ordered By Practitioner (practitioner)
2)Ordered By Practitioner Name (practitioner_name)

Updated create_therapy_plan in patient_encounter.py (line 409)
Populated the above fields as :
doc.practitioner = encounter.practitioner
doc.practitioner_name = encounter.practitioner_name

Also updated test_therapy_plan.py  to populate practitioner fields in test plan.

Why:-
Therapy Plans should capture who ordered the plan for better traceability and consistency with other healthcare documents.
Without this change, the newly added Therapy Plan fields remained empty when the plan was created from a Patient Encounter.

Impact:-
New Therapy Plans created from Patient Encounters will automatically store the ordering practitioner and practitioner name.
Existing Therapy Plans are not affected.

<img width="1008" height="458" alt="image" src="https://github.com/user-attachments/assets/ed3f7838-ea0c-4a76-905d-86beec4e27f9" />

Closes Issue #587 
no-docs