### PR TITLE
fix: rename make_insurance_coverage method to avoid semgrep monkey-patch false positive

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -26,7 +26,7 @@ from erpnext.stock.get_item_details import ItemDetailsCtx, get_item_details
 from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings import get_account
 from healthcare.healthcare.doctype.nursing_task.nursing_task import NursingTask
 from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
-	make_insurance_coverage,
+	make_insurance_coverage as generate_insurance_coverage,
 )
 from healthcare.healthcare.utils import (
 	get_appointment_billing_item_and_rate,
@@ -308,7 +308,7 @@ class InpatientRecord(Document):
 
 	def make_insurance_coverage(self, service_unit_type, qty):
 		billing_detail = get_appointment_billing_item_and_rate(self)
-		return make_insurance_coverage(
+		return generate_insurance_coverage(
 			patient=self.patient,
 			policy=self.insurance_policy,
 			company=self.company,

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -34,7 +34,7 @@ from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings impor
 	get_receivable_account,
 )
 from healthcare.healthcare.doctype.patient_insurance_coverage.patient_insurance_coverage import (
-	make_insurance_coverage,
+	make_insurance_coverage as generate_insurance_coverage,
 )
 from healthcare.healthcare.utils import get_appointment_billing_item_and_rate
 
@@ -99,7 +99,7 @@ class PatientAppointment(Document):
 
 	def make_insurance_coverage(self):
 		billing_detail = get_appointment_billing_item_and_rate(self)
-		coverage = make_insurance_coverage(
+		coverage = generate_insurance_coverage(
 			patient=self.patient,
 			policy=self.insurance_policy,
 			company=self.company,


### PR DESCRIPTION
Semgrep's frappe-monkey-patching-not-allowed rule flagged both files, because the method name collided with the imported function name

Affected files:
- inpatient_record.py
- patient_appointment.py