### PR TITLE
fix: tharapy session fetched for billing twice

### DIFF
--- a/healthcare/healthcare/doctype/therapy_plan/therapy_plan.py
+++ b/healthcare/healthcare/doctype/therapy_plan/therapy_plan.py
@@ -69,6 +69,12 @@ def make_therapy_session(
 	service_request: str | None = None,
 	practitioner: str | None = None,
 ) -> dict:
+	if not service_request and therapy_plan:
+		tp_doc = frappe.get_cached_doc("Therapy Plan", therapy_plan)
+		service_request = frappe.db.exists(
+			"Service Request", {"template_dn": therapy_type, "order_group": tp_doc.order_group}
+		)
+
 	sr_doc = None
 	if service_request:
 		if (


### PR DESCRIPTION
- this happens when the Therapy Session is created from the Therapy Plan
- closes [996](#996)