### PR TITLE
feat(diagnostic-report): generate separate diagnostic reports per observation category

### DIFF
--- a/healthcare/healthcare/api/patient_portal.py
+++ b/healthcare/healthcare/api/patient_portal.py
@@ -8,6 +8,9 @@ from frappe.utils import get_datetime, get_time, getdate
 
 import erpnext
 
+from healthcare.healthcare.doctype.diagnostic_report.diagnostic_report import (
+	get_observation_category_from_title,
+)
 from healthcare.healthcare.doctype.observation.observation import get_observation_reference
 from healthcare.healthcare.utils import get_appointment_billing_item_and_rate
 
@@ -256,11 +259,17 @@ def get_orders():
 
 	# Get all tests via service requests for the patients
 	tests_via_service_requests = get_data_from_service_requests(patients)
-	service_request_map = build_order_map(tests_via_service_requests)
+	service_request_reports = get_diagnostic_report_lookup(
+		"Patient Encounter", [row.order_name for row in tests_via_service_requests]
+	)
+	service_request_map = build_order_map(tests_via_service_requests, service_request_reports)
 
 	# Get all tests via sale invoice for the patients
 	tests_via_invoices = get_data_from_invoices(patients)
-	invoice_map = build_order_map(tests_via_invoices, True)
+	invoice_reports = get_diagnostic_report_lookup(
+		"Sales Invoice", [row.order_name for row in tests_via_invoices]
+	)
+	invoice_map = build_order_map(tests_via_invoices, invoice_reports, True)
 
 	all_tests = {**service_request_map, **invoice_map}
 
@@ -270,7 +279,7 @@ def get_orders():
 	return list(dict(sorted_tests).values())
 
 
-def build_order_map(orders, from_invoice=False):
+def build_order_map(orders, report_lookup, from_invoice=False):
 	orders_map = {}
 	for row in orders:
 		patient_doc = frappe.get_doc("Patient", row.patient)
@@ -291,14 +300,20 @@ def build_order_map(orders, from_invoice=False):
 				"patient_name": row.patient_name,
 				"ref_practitioner": row.ref_practitioner_name,
 				"order_date": row.order_date,
-				"diagnostic_report": row.diagnostic_report,
-				"diagnostic_report_status": row.diagnostic_report_status,
+				"diagnostic_report": None,
+				"diagnostic_report_status": None,
+				"diagnostic_reports": [],
 				"billing_status": billing_status,
 				"collection_point": row.collection_point,
 				"invoice": [],
 				"patient_image": row.patient_image,
 				"tests": [],
 			}
+
+		add_diagnostic_report_to_order(
+			orders_map[key],
+			report_lookup.get((row.order_name, row.observation_category)),
+		)
 
 		invoice = None
 		if row.billing_status in ["Invoiced", "Partly Invoiced", "Paid", "Partly Paid"]:
@@ -314,12 +329,70 @@ def build_order_map(orders, from_invoice=False):
 
 		orders_map[key]["tests"].append(build_template_dict(row))
 
+	for order in orders_map.values():
+		order["diagnostic_report_status"] = summarize_diagnostic_report_status(
+			order["diagnostic_reports"]
+		)
+		if len(order["diagnostic_reports"]) == 1:
+			order["diagnostic_report"] = order["diagnostic_reports"][0]["name"]
+
 	return orders_map
+
+
+def get_diagnostic_report_lookup(ref_doctype, docnames):
+	if not docnames:
+		return {}
+
+	report_rows = frappe.get_all(
+		"Diagnostic Report",
+		filters={"ref_doctype": ref_doctype, "docname": ["in", list(set(docnames))]},
+		fields=["name", "docname", "status", "title"],
+	)
+
+	report_lookup = {}
+	for row in report_rows:
+		observation_category = get_observation_category_from_title(row.get("title"))
+		if not observation_category:
+			continue
+		report_lookup[(row.get("docname"), observation_category)] = {
+			"name": row.get("name"),
+			"status": row.get("status"),
+			"observation_category": observation_category,
+		}
+
+	return report_lookup
+
+
+def add_diagnostic_report_to_order(order, report):
+	if not report:
+		return
+
+	if any(existing["name"] == report["name"] for existing in order["diagnostic_reports"]):
+		return
+
+	order["diagnostic_reports"].append(report)
+	order["diagnostic_reports"].sort(key=lambda item: item["observation_category"])
+
+
+def summarize_diagnostic_report_status(reports):
+	if not reports:
+		return None
+
+	statuses = {report.get("status") for report in reports if report.get("status")}
+	if len(statuses) == 1:
+		return next(iter(statuses))
+
+	if "Partially Approved" in statuses:
+		return "Partially Approved"
+	if "Open" in statuses:
+		return "Open"
+	return "Multiple"
 
 
 def build_template_dict(row):
 	test_dict = {
 		"observation_template": row.observation_template,
+		"observation_category": row.observation_category,
 		"service_request": row.get("service_request"),
 		"observation": row.observation,
 		"reference": get_observation_reference(row) if row.observation else None,
@@ -437,7 +510,6 @@ def get_data_from_service_requests(patients):
 	observation_template = frappe.qb.DocType("Observation Template")
 	sample_collection = frappe.qb.DocType("Sample Collection")
 	sample_collection_item = frappe.qb.DocType("Observation Sample Collection")
-	diagnostic_report = frappe.qb.DocType("Diagnostic Report")
 	patient = frappe.qb.DocType("Patient")
 
 	rows = (
@@ -454,8 +526,6 @@ def get_data_from_service_requests(patients):
 		.on(service_request.name == sample_collection_item.service_request)
 		.left_join(sample_collection)
 		.on(sample_collection_item.parent == sample_collection.name)
-		.left_join(diagnostic_report)
-		.on(service_request.order_group == diagnostic_report.docname)
 		.left_join(patient)
 		.on(service_request.patient == patient.name)
 		.select(
@@ -480,6 +550,7 @@ def get_data_from_service_requests(patients):
 			observation_template.permitted_data_type,
 			observation_template.sample_collection_required,
 			observation_template.has_component,
+			observation_template.observation_category,
 		)
 		.select(
 			sample_collection_item.name.as_("observation_sample_collection"),
@@ -490,10 +561,6 @@ def get_data_from_service_requests(patients):
 		.select(
 			sample_collection.status.as_("sample_collection_status"),
 			sample_collection.collection_point,
-		)
-		.select(
-			diagnostic_report.name.as_("diagnostic_report"),
-			diagnostic_report.status.as_("diagnostic_report_status"),
 		)
 		.select(
 			patient.sex.as_("gender"),
@@ -510,7 +577,6 @@ def get_data_from_service_requests(patients):
 
 
 def get_data_from_invoices(patients):
-	diagnostic_report = frappe.qb.DocType("Diagnostic Report")
 	si_item = frappe.qb.DocType("Sales Invoice Item")
 	si = frappe.qb.DocType("Sales Invoice")
 	observation = frappe.qb.DocType("Observation")
@@ -520,15 +586,13 @@ def get_data_from_invoices(patients):
 	patient = frappe.qb.DocType("Patient")
 
 	rows = (
-		frappe.qb.from_(diagnostic_report)
-		.left_join(si_item)
-		.on((diagnostic_report.docname == si_item.parent) & (si_item.reference_dn.isnull()))
+		frappe.qb.from_(si_item)
 		.left_join(si)
 		.on(si.name == si_item.parent)
 		.left_join(observation_template)
 		.on(si_item.item_code == observation_template.item)
 		.left_join(sample_collection)
-		.on(diagnostic_report.docname == sample_collection.reference_name)
+		.on(si.name == sample_collection.reference_name)
 		.left_join(sample_collection_item)
 		.on(
 			(sample_collection.name == sample_collection_item.parent)
@@ -537,7 +601,7 @@ def get_data_from_invoices(patients):
 		.left_join(observation)
 		.on(
 			(
-				(diagnostic_report.docname == observation.sales_invoice)
+				(si.name == observation.sales_invoice)
 				| (sample_collection.name == observation.reference_docname)
 			)
 			& (observation.docstatus == 1)
@@ -545,16 +609,14 @@ def get_data_from_invoices(patients):
 			& (observation_template.name == observation.observation_template)
 		)
 		.left_join(patient)
-		.on(diagnostic_report.patient == patient.name)
+		.on(si.patient == patient.name)
 		.select(
-			diagnostic_report.docname.as_("order_name"),
-			diagnostic_report.patient,
-			diagnostic_report.patient_name,
-			diagnostic_report.practitioner.as_("ref_practitioner"),
-			diagnostic_report.practitioner_name.as_("ref_practitioner_name"),
-			diagnostic_report.reference_posting_date.as_("order_date"),
-			diagnostic_report.name.as_("diagnostic_report"),
-			diagnostic_report.status.as_("diagnostic_report_status"),
+			si.name.as_("order_name"),
+			si.patient,
+			si.patient_name,
+			si.ref_practitioner.as_("ref_practitioner"),
+			si.ref_practitioner.as_("ref_practitioner_name"),
+			si.posting_date.as_("order_date"),
 		)
 		.select(
 			si.status.as_("billing_status"),
@@ -565,6 +627,7 @@ def get_data_from_invoices(patients):
 			observation_template.permitted_data_type,
 			observation_template.sample_collection_required,
 			observation_template.has_component,
+			observation_template.observation_category,
 		)
 		.select(
 			observation.name.as_("observation"),
@@ -586,10 +649,11 @@ def get_data_from_invoices(patients):
 			patient.sex.as_("gender"),
 			patient.image.as_("patient_image"),
 		)
-		.where(diagnostic_report.patient.isin(patients))
+		.where(si.patient.isin(patients))
 		.where(observation_template.name.isnotnull())
+		.where(si_item.reference_dn.isnull())
 		.where(si.docstatus == 1)
-		.orderby(diagnostic_report.reference_posting_date, order=Order.desc)
+		.orderby(si.posting_date, order=Order.desc)
 		.orderby(si_item.idx, order=Order.asc)
 	)
 

--- a/healthcare/healthcare/api/patient_portal.py
+++ b/healthcare/healthcare/api/patient_portal.py
@@ -312,7 +312,8 @@ def build_order_map(orders, report_lookup, from_invoice=False):
 
 		add_diagnostic_report_to_order(
 			orders_map[key],
-			report_lookup.get((row.order_name, row.observation_category)),
+			report_lookup.get((row.order_name, row.observation_category))
+			or report_lookup.get((row.order_name, None)),
 		)
 
 		invoice = None
@@ -352,12 +353,10 @@ def get_diagnostic_report_lookup(ref_doctype, docnames):
 	report_lookup = {}
 	for row in report_rows:
 		observation_category = get_observation_category_from_title(row.get("title"))
-		if not observation_category:
-			continue
 		report_lookup[(row.get("docname"), observation_category)] = {
 			"name": row.get("name"),
 			"status": row.get("status"),
-			"observation_category": observation_category,
+			"observation_category": observation_category or "Unspecified",
 		}
 
 	return report_lookup

--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
@@ -5,7 +5,38 @@ import frappe
 from frappe.model.document import Document
 from frappe.model.workflow import get_workflow_name, get_workflow_state_field
 
-from healthcare.healthcare.doctype.observation.observation import get_observation_details
+CATEGORY_TITLE_MARKER = " [Observation Category: {0}]"
+
+
+def get_diagnostic_report_base_title(patient_name, age, gender):
+	return f"{patient_name} - {age or ''} {gender}"
+
+
+def get_diagnostic_report_title(patient_name, age, gender, observation_category=None):
+	title = get_diagnostic_report_base_title(patient_name, age, gender)
+	if observation_category:
+		title += CATEGORY_TITLE_MARKER.format(observation_category)
+	return title
+
+
+def get_observation_category_from_title(title):
+	if not title or "[Observation Category:" not in title:
+		return None
+
+	prefix, _, suffix = title.rpartition("[Observation Category:")
+	if not suffix:
+		return None
+
+	category = suffix.rstrip("]").strip()
+	return category or None
+
+
+def get_diagnostic_report_name(ref_doctype, docname, observation_category=None):
+	filters = {"ref_doctype": ref_doctype, "docname": docname}
+	if observation_category:
+		filters["title"] = ["like", f"%{CATEGORY_TITLE_MARKER.format(observation_category)}"]
+
+	return frappe.db.get_value("Diagnostic Report", filters, "name")
 
 
 class DiagnosticReport(Document):
@@ -26,7 +57,10 @@ class DiagnosticReport(Document):
 				self.age = patient_doc.calculate_age(self.reference_posting_date).get("age_in_string")
 
 	def set_title(self):
-		self.title = f"{self.patient_name} - {self.age or ''} {self.gender}"
+		observation_category = get_observation_category_from_title(self.title)
+		self.title = get_diagnostic_report_title(
+			self.patient_name, self.age, self.gender, observation_category
+		)
 
 	def set_reference_details(self):
 		if self.ref_doctype == "Sales Invoice" and self.docname:
@@ -38,22 +72,24 @@ class DiagnosticReport(Document):
 
 
 def diagnostic_report_print(diagnostic_report):
+	from healthcare.healthcare.doctype.observation.observation import get_observation_details
+
 	return get_observation_details(diagnostic_report)
 
 
 def validate_observations_has_result(doc):
 	if doc.ref_doctype == "Sales Invoice":
 		submittable = True
-		observations = frappe.db.get_all(
-			"Observation",
-			{
-				"sales_invoice": doc.docname,
-				"docstatus": ["!=", 2],
-				"has_component": False,
-				"status": ["!=", "Cancelled"],
-			},
-			pluck="name",
-		)
+		filters = {
+			"sales_invoice": doc.docname,
+			"docstatus": ["!=", 2],
+			"has_component": False,
+			"status": ["!=", "Cancelled"],
+		}
+		observation_category = get_observation_category_from_title(doc.title)
+		if observation_category:
+			filters["observation_category"] = observation_category
+		observations = frappe.db.get_all("Observation", filters, pluck="name")
 		for obs in observations:
 			if not frappe.get_doc("Observation", obs).has_result():
 				submittable = False
@@ -63,10 +99,16 @@ def validate_observations_has_result(doc):
 def set_diagnostic_status(doc):
 	if doc.get("__islocal"):
 		return
-	observations = frappe.db.get_all(
-		"Observation",
-		{"sales_invoice": doc.docname, "docstatus": 0, "status": ["!=", "Approved"], "has_component": 0},
-	)
+	filters = {
+		"sales_invoice": doc.docname,
+		"docstatus": 0,
+		"status": ["!=", "Approved"],
+		"has_component": 0,
+	}
+	observation_category = get_observation_category_from_title(doc.title)
+	if observation_category:
+		filters["observation_category"] = observation_category
+	observations = frappe.db.get_all("Observation", filters)
 	workflow_name = get_workflow_name("Diagnostic Report")
 	workflow_state_field = get_workflow_state_field(workflow_name)
 	if observations and len(observations) > 0:
@@ -81,16 +123,16 @@ def set_diagnostic_status(doc):
 def set_observation_status(docname):
 	doc = frappe.get_doc("Diagnostic Report", docname)
 	if doc.ref_doctype == "Sales Invoice":
-		observations = frappe.db.get_all(
-			"Observation",
-			{
-				"sales_invoice": doc.docname,
-				"docstatus": ["!=", 2],
-				"has_component": False,
-				"status": ["not in", ["Cancelled", "Approved", "Rejected"]],
-			},
-			pluck="name",
-		)
+		filters = {
+			"sales_invoice": doc.docname,
+			"docstatus": ["!=", 2],
+			"has_component": False,
+			"status": ["not in", ["Cancelled", "Approved", "Rejected"]],
+		}
+		observation_category = get_observation_category_from_title(doc.title)
+		if observation_category:
+			filters["observation_category"] = observation_category
+		observations = frappe.db.get_all("Observation", filters, pluck="name")
 		if observations:
 			for obs in observations:
 				if doc.status in ["Approved", "Rejected"]:

--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
@@ -23,7 +23,7 @@ def get_observation_category_from_title(title):
 	if not title or "[Observation Category:" not in title:
 		return None
 
-	prefix, _, suffix = title.rpartition("[Observation Category:")
+	_, _, suffix = title.rpartition("[Observation Category:")
 	if not suffix:
 		return None
 

--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -13,6 +13,10 @@ from frappe.utils import flt, get_link_to_form, getdate, now_datetime, nowdate
 from erpnext.setup.doctype.terms_and_conditions.terms_and_conditions import (
 	get_terms_and_conditions,
 )
+from healthcare.healthcare.doctype.diagnostic_report.diagnostic_report import (
+	get_diagnostic_report_name,
+	get_observation_category_from_title,
+)
 
 
 class Observation(Document):
@@ -136,19 +140,26 @@ class Observation(Document):
 
 @frappe.whitelist()
 def get_observation_details(docname):
-	reference = frappe.get_value("Diagnostic Report", docname, ["docname", "ref_doctype"], as_dict=True)
+	reference = frappe.get_value(
+		"Diagnostic Report", docname, ["docname", "ref_doctype", "title"], as_dict=True
+	)
+	observation_category = get_observation_category_from_title(reference.get("title"))
 	observation = []
 
 	if reference.get("ref_doctype") == "Sales Invoice":
+		filters = {
+			"sales_invoice": reference.get("docname"),
+			"parent_observation": "",
+			"status": ["!=", "Cancelled"],
+			"docstatus": ["!=", 2],
+		}
+		if observation_category:
+			filters["observation_category"] = observation_category
+
 		observation = frappe.get_list(
 			"Observation",
 			fields=["*"],
-			filters={
-				"sales_invoice": reference.get("docname"),
-				"parent_observation": "",
-				"status": ["!=", "Cancelled"],
-				"docstatus": ["!=", 2],
-			},
+			filters=filters,
 			order_by="creation",
 		)
 	elif reference.get("ref_doctype") == "Patient Encounter":
@@ -163,15 +174,19 @@ def get_observation_details(docname):
 			order_by="creation",
 			pluck="name",
 		)
+		filters = {
+			"service_request": ["in", service_requests],
+			"parent_observation": "",
+			"status": ["!=", "Cancelled"],
+			"docstatus": ["!=", 2],
+		}
+		if observation_category:
+			filters["observation_category"] = observation_category
+
 		observation = frappe.get_list(
 			"Observation",
 			fields=["*"],
-			filters={
-				"service_request": ["in", service_requests],
-				"parent_observation": "",
-				"status": ["!=", "Cancelled"],
-				"docstatus": ["!=", 2],
-			},
+			filters=filters,
 			order_by="creation",
 		)
 
@@ -529,9 +544,13 @@ def set_diagnostic_report_status(doc):
 				"Sample Collection", doc.reference_docname, ["reference_doc", "reference_name"]
 			)
 
-		diagnostic_report = frappe.db.get_value(
-			"Diagnostic Report", {"ref_doctype": ref_doctype, "docname": ref_docname}, "name"
+		diagnostic_report = get_diagnostic_report_name(
+			ref_doctype, ref_docname, doc.observation_category
 		)
+		if not diagnostic_report:
+			diagnostic_report = frappe.db.get_value(
+				"Diagnostic Report", {"ref_doctype": ref_doctype, "docname": ref_docname}, "name"
+			)
 
 		if diagnostic_report:
 			out_data, obs_length = get_observation_details(diagnostic_report)

--- a/healthcare/healthcare/doctype/observation/test_observation.py
+++ b/healthcare/healthcare/doctype/observation/test_observation.py
@@ -9,6 +9,11 @@ from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings impor
 	get_income_account,
 	get_receivable_account,
 )
+from healthcare.healthcare.doctype.diagnostic_report.diagnostic_report import (
+	get_diagnostic_report_name,
+	get_diagnostic_report_title,
+)
+from healthcare.healthcare.doctype.observation.observation import get_observation_details
 from healthcare.tests.utils import HealthcareTestSuite
 
 
@@ -180,6 +185,94 @@ class TestObservation(HealthcareTestSuite):
 				},
 			)
 		)
+
+	def test_category_specific_reports_filter_observations(self):
+		self.enable_observation_on_invoice_submit()
+
+		patient = self.get_test_patient()
+		sales_invoice = create_sales_invoice(patient, "_Test Observation without Sample")
+		lab_report = get_diagnostic_report_name("Sales Invoice", sales_invoice.name, "Laboratory")
+		self.assertTrue(lab_report)
+
+		imaging_template = ensure_imaging_observation_template()
+		imaging_observation = frappe.new_doc("Observation")
+		imaging_observation.posting_datetime = getdate()
+		imaging_observation.patient = patient
+		imaging_observation.observation_template = imaging_template.name
+		imaging_observation.sales_invoice = sales_invoice.name
+		imaging_observation.company = sales_invoice.company
+		imaging_observation.result_text = "Clear"
+		imaging_observation.insert(ignore_permissions=True)
+
+		patient_doc = frappe.get_doc("Patient", patient)
+		imaging_report = frappe.new_doc("Diagnostic Report")
+		imaging_report.company = sales_invoice.company
+		imaging_report.patient = patient
+		imaging_report.ref_doctype = "Sales Invoice"
+		imaging_report.docname = sales_invoice.name
+		imaging_report.title = get_diagnostic_report_title(
+			patient_doc.patient_name,
+			patient_doc.calculate_age(sales_invoice.posting_date).get("age_in_string"),
+			patient_doc.sex,
+			"Imaging",
+		)
+		imaging_report.save(ignore_permissions=True)
+
+		lab_data, _ = get_observation_details(lab_report)
+		imaging_data, _ = get_observation_details(imaging_report.name)
+
+		self.assertEqual(["Laboratory"], [row["observation"]["observation_category"] for row in lab_data])
+		self.assertEqual(["Imaging"], [row["observation"]["observation_category"] for row in imaging_data])
+
+	def test_category_specific_status_updates_only_matching_report(self):
+		self.enable_observation_on_invoice_submit()
+
+		patient = self.get_test_patient()
+		sales_invoice = create_sales_invoice(patient, "_Test Observation without Sample")
+		lab_report = get_diagnostic_report_name("Sales Invoice", sales_invoice.name, "Laboratory")
+		self.assertTrue(lab_report)
+
+		imaging_template = ensure_imaging_observation_template()
+		imaging_observation = frappe.new_doc("Observation")
+		imaging_observation.posting_datetime = getdate()
+		imaging_observation.patient = patient
+		imaging_observation.observation_template = imaging_template.name
+		imaging_observation.sales_invoice = sales_invoice.name
+		imaging_observation.company = sales_invoice.company
+		imaging_observation.result_text = "Clear"
+		imaging_observation.insert(ignore_permissions=True)
+
+		patient_doc = frappe.get_doc("Patient", patient)
+		imaging_report = frappe.new_doc("Diagnostic Report")
+		imaging_report.company = sales_invoice.company
+		imaging_report.patient = patient
+		imaging_report.ref_doctype = "Sales Invoice"
+		imaging_report.docname = sales_invoice.name
+		imaging_report.title = get_diagnostic_report_title(
+			patient_doc.patient_name,
+			patient_doc.calculate_age(sales_invoice.posting_date).get("age_in_string"),
+			patient_doc.sex,
+			"Imaging",
+		)
+		imaging_report.save(ignore_permissions=True)
+
+		lab_observation = frappe.get_all(
+			"Observation",
+			filters={
+				"sales_invoice": sales_invoice.name,
+				"observation_category": "Laboratory",
+			},
+			fields=["name"],
+			limit=1,
+		)[0]
+		lab_observation_doc = frappe.get_doc("Observation", lab_observation.name)
+		lab_observation_doc.result_data = "5"
+		lab_observation_doc.status = "Approved"
+		lab_observation_doc.save()
+		lab_observation_doc.submit()
+
+		self.assertEqual("Approved", frappe.db.get_value("Diagnostic Report", lab_report, "status"))
+		self.assertEqual("Open", frappe.db.get_value("Diagnostic Report", imaging_report.name, "status"))
 
 	def test_formula_computes_result(self):
 		self.enable_observation_on_invoice_submit()
@@ -408,3 +501,19 @@ def create_patient_encounter(patient, observation_template):
 
 	patient_encounter.submit()
 	return patient_encounter
+
+
+def ensure_imaging_observation_template():
+	template_name = "_Test Imaging Observation"
+	if frappe.db.exists("Observation Template", template_name):
+		return frappe.get_doc("Observation Template", template_name)
+
+	template = frappe.new_doc("Observation Template")
+	template.observation = template_name
+	template.abbr = "TIO"
+	template.observation_category = "Imaging"
+	template.permitted_data_type = "Text"
+	template.sample_collection_required = 0
+	template.item_group = "Services"
+	template.insert(ignore_permissions=True)
+	return template

--- a/healthcare/healthcare/doctype/observation/test_observation.py
+++ b/healthcare/healthcare/doctype/observation/test_observation.py
@@ -221,8 +221,12 @@ class TestObservation(HealthcareTestSuite):
 		lab_data, _ = get_observation_details(lab_report)
 		imaging_data, _ = get_observation_details(imaging_report.name)
 
-		self.assertEqual(["Laboratory"], [row["observation"]["observation_category"] for row in lab_data])
-		self.assertEqual(["Imaging"], [row["observation"]["observation_category"] for row in imaging_data])
+		self.assertTrue(lab_data)
+		self.assertTrue(imaging_data)
+		self.assertEqual(
+			{"Laboratory"}, {row["observation"]["observation_category"] for row in lab_data}
+		)
+		self.assertEqual({"Imaging"}, {row["observation"]["observation_category"] for row in imaging_data})
 
 	def test_category_specific_status_updates_only_matching_report(self):
 		self.enable_observation_on_invoice_submit()
@@ -505,13 +509,16 @@ def create_patient_encounter(patient, observation_template):
 
 def ensure_imaging_observation_template():
 	template_name = "_Test Imaging Observation"
+	expected_category = "Imaging"
 	if frappe.db.exists("Observation Template", template_name):
-		return frappe.get_doc("Observation Template", template_name)
+		template = frappe.get_doc("Observation Template", template_name)
+		if template.observation_category == expected_category:
+			return template
 
 	template = frappe.new_doc("Observation Template")
 	template.observation = template_name
 	template.abbr = "TIO"
-	template.observation_category = "Imaging"
+	template.observation_category = expected_category
 	template.permitted_data_type = "Text"
 	template.sample_collection_required = 0
 	template.item_group = "Services"

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -67,12 +67,13 @@ class SampleCollection(Document):
 						"Service Request", obs.get("service_request"), "status", "active-Request Status"
 					)
 
-		exist_diagnostic_report = frappe.db.exists(
+		existing_diagnostic_reports = frappe.get_all(
 			"Diagnostic Report",
-			{"sample_collection": self.name},
+			filters={"sample_collection": self.name},
+			pluck="name",
 		)
-		if exist_diagnostic_report:
-			frappe.delete_doc("Diagnostic Report", exist_diagnostic_report)
+		for diagnostic_report in existing_diagnostic_reports:
+			frappe.delete_doc("Diagnostic Report", diagnostic_report)
 
 
 @frappe.whitelist()

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -10,6 +10,10 @@ from frappe.model.mapper import get_mapped_doc
 from frappe.utils import now_datetime
 
 from healthcare.controllers.service_request_controller import ServiceRequestController
+from healthcare.healthcare.doctype.diagnostic_report.diagnostic_report import (
+	get_diagnostic_report_name,
+	get_diagnostic_report_title,
+)
 from healthcare.healthcare.doctype.observation.observation import add_observation
 from healthcare.healthcare.doctype.observation_template.observation_template import (
 	get_observation_template_details,
@@ -344,9 +348,16 @@ def make_observation(service_request, appointment=None):
 		else:
 			observation = create_observation(service_request, appointment)
 
-	diagnostic_report = frappe.db.exists("Diagnostic Report", {"docname": service_request.order_group})
+	observation_category = frappe.db.get_value(
+		"Observation Template", service_request.template_dn, "observation_category"
+	)
+	diagnostic_report = get_diagnostic_report_name(
+		service_request.source_doc, service_request.order_group, observation_category
+	)
 	if not diagnostic_report:
-		insert_diagnostic_report(service_request, sample_collection.name if sample_collection else None)
+		diagnostic_report = insert_diagnostic_report(
+			service_request, sample_collection.name if sample_collection else None, observation_category
+		)
 
 	if sample_collection:
 		if diagnostic_report and not frappe.db.get_value(
@@ -401,7 +412,7 @@ def create_observation(service_request, appointment=None):
 	return doc
 
 
-def insert_diagnostic_report(doc, sample_collection=None):
+def insert_diagnostic_report(doc, sample_collection=None, observation_category=None):
 	diagnostic_report = frappe.new_doc("Diagnostic Report")
 	diagnostic_report.company = doc.company
 	diagnostic_report.patient = doc.patient
@@ -409,7 +420,13 @@ def insert_diagnostic_report(doc, sample_collection=None):
 	diagnostic_report.docname = doc.order_group
 	diagnostic_report.practitioner = doc.practitioner
 	diagnostic_report.sample_collection = sample_collection
+	patient_doc = frappe.get_doc("Patient", doc.patient)
+	age = patient_doc.calculate_age().get("age_in_string") if patient_doc.dob else ""
+	diagnostic_report.title = get_diagnostic_report_title(
+		patient_doc.patient_name, age, patient_doc.sex, observation_category
+	)
 	diagnostic_report.save(ignore_permissions=True)
+	return diagnostic_report.name
 
 
 def check_observation_sample_exist(service_request):

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1519,7 +1519,6 @@ def company_on_trash(doc, method):
 
 def create_sample_collection_and_observation(doc):
 	meta = frappe.get_meta("Sales Invoice Item", cached=True)
-	diag_report_required = False
 	data = []
 	for item in doc.items:
 		# to set patient in item table if not set

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -18,6 +18,10 @@ from healthcare.healthcare.doctype.fee_validity.fee_validity import (
 	get_fee_validity,
 	manage_fee_validity,
 )
+from healthcare.healthcare.doctype.diagnostic_report.diagnostic_report import (
+	get_diagnostic_report_name,
+	get_diagnostic_report_title,
+)
 from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings import (
 	get_income_account,
 )
@@ -1572,8 +1576,10 @@ def create_sample_collection_and_observation(doc):
 		if grouped:
 			out_data = grouped
 
+	report_categories = set()
 	for grp in out_data:
 		patient = doc.patient
+		report_categories = set()
 		if meta.has_field("patient") and grp:
 			patient = grp
 		if meta.has_field("patient"):
@@ -1581,17 +1587,18 @@ def create_sample_collection_and_observation(doc):
 			for obs in out_data[grp]:
 				(
 					sample_collection,
-					diag_report_required,
+					group_report_categories,
 				) = insert_observation_and_sample_collection(
 					doc, patient, obs, sample_collection, obs.get("child")
 				)
+				report_categories.update(group_report_categories)
 			if sample_collection and len(sample_collection.get("observation_sample_collection")) > 0:
 				sample_collection.save(ignore_permissions=True)
 
-			if diag_report_required:
-				insert_diagnostic_report(doc, patient, sample_collection.name)
+			for observation_category in report_categories:
+				insert_diagnostic_report(doc, patient, sample_collection.name, observation_category)
 		else:
-			sample_collection, diag_report_required = insert_observation_and_sample_collection(
+			sample_collection, report_categories = insert_observation_and_sample_collection(
 				doc, patient, grp, sample_collection
 			)
 
@@ -1599,8 +1606,8 @@ def create_sample_collection_and_observation(doc):
 		if sample_collection and len(sample_collection.get("observation_sample_collection")) > 0:
 			sample_collection.save(ignore_permissions=True)
 
-		if diag_report_required:
-			insert_diagnostic_report(doc, patient, sample_collection.name)
+		for observation_category in report_categories:
+			insert_diagnostic_report(doc, patient, sample_collection.name, observation_category)
 
 
 def create_sample_collection(doc, patient):
@@ -1616,8 +1623,12 @@ def create_sample_collection(doc, patient):
 	return sample_collection
 
 
-def insert_diagnostic_report(doc, patient, sample_collection=None):
-	if not frappe.db.exists("Diagnostic Report", {"docname": doc.name}):
+def get_observation_template_category(template_name):
+	return frappe.db.get_value("Observation Template", template_name, "observation_category")
+
+
+def insert_diagnostic_report(doc, patient, sample_collection=None, observation_category=None):
+	if not get_diagnostic_report_name(doc.doctype, doc.name, observation_category):
 		diagnostic_report = frappe.new_doc("Diagnostic Report")
 		diagnostic_report.company = doc.company
 		diagnostic_report.patient = patient
@@ -1625,15 +1636,21 @@ def insert_diagnostic_report(doc, patient, sample_collection=None):
 		diagnostic_report.docname = doc.name
 		diagnostic_report.practitioner = doc.ref_practitioner
 		diagnostic_report.sample_collection = sample_collection
+		patient_doc = frappe.get_doc("Patient", patient)
+		age = patient_doc.calculate_age(doc.posting_date).get("age_in_string") if patient_doc.dob else ""
+		diagnostic_report.title = get_diagnostic_report_title(
+			patient_doc.patient_name, age, patient_doc.sex, observation_category
+		)
 		diagnostic_report.save(ignore_permissions=True)
 
 
 def insert_observation_and_sample_collection(
 	doc, patient, grp, sample_collection, child=None, parent_observation=None
 ):
-	diag_report_required = False
+	report_categories = set()
+	observation_category = get_observation_template_category(grp.get("name"))
 	if grp.get("has_component"):
-		diag_report_required = True
+		report_categories.add(observation_category)
 
 		# parent observation
 		current_parent_observation = add_observation(
@@ -1691,7 +1708,7 @@ def insert_observation_and_sample_collection(
 						parent_observation=current_parent_observation,
 					)
 					sample_collection = sub_sc
-					diag_report_required = diag_report_required or sub_drc
+					report_categories.update(sub_drc)
 				else:
 					add_observation(
 						patient=patient,
@@ -1729,10 +1746,10 @@ def insert_observation_and_sample_collection(
 						parent_observation=current_parent_observation,
 					)
 					sample_collection = sub_sc
-					diag_report_required = diag_report_required or sub_drc
+					report_categories.update(sub_drc)
 
 	else:
-		diag_report_required = True
+		report_categories.add(observation_category)
 		# create observation for non sample_collection_reqd individual templates
 		if not grp.get("sample_collection_required"):
 			add_observation(
@@ -1755,7 +1772,7 @@ def insert_observation_and_sample_collection(
 					"reference_child": child if child else "",
 				},
 			)
-	return sample_collection, diag_report_required
+	return sample_collection, report_categories
 
 
 def has_direct_leaf_component(template_name):

--- a/patient_portal/src/components/DiagnosticModel.vue
+++ b/patient_portal/src/components/DiagnosticModel.vue
@@ -15,7 +15,7 @@
 				<div class="flex items-center justify-between whitespace-nowrap">
 					<h3 class="text-xs font-medium text-gray-500 truncate"># {{ item.order_name }}</h3>
 					<Badge v-if="item.diagnostic_report_status" :variant="'outline'"
-						:theme="item.diagnostic_report_status == 'Approved' ? 'green' : 'orange'">
+						:theme="getStatusColor(item.diagnostic_report_status)">
 						{{ item.diagnostic_report_status }}
 					</Badge>
 				</div>
@@ -27,8 +27,8 @@
 				<p v-if="item.ref_practitioner" class="mt-1 text-xs text-gray-600 whitespace-nowrap truncate">
 					Practitioner: {{ item.ref_practitioner }}
 				</p>
-				<p v-if="item.diagnostic_report" class="mt-1 text-xs text-gray-600 whitespace-nowrap truncate">
-					# {{ item.diagnostic_report }}
+				<p v-if="item.diagnostic_reports?.length" class="mt-1 text-xs text-gray-600 whitespace-nowrap truncate">
+					Reports: {{ item.diagnostic_reports.length }}
 				</p>
 
 				<p class="mt-1 text-xs text-gray-600 whitespace-nowrap">
@@ -72,7 +72,7 @@
 			<div class="py-2 flex items-center justify-between gap-2">
 				<p class="text-sm text-gray-500"># {{ selectedOrder.order_name }}</p>
 				<Badge v-if="selectedOrder.diagnostic_report_status" :variant="'outline'"
-					:theme="selectedOrder.diagnostic_report_status == 'Approved' ? 'green' : 'orange'">
+					:theme="getStatusColor(selectedOrder.diagnostic_report_status)">
 					{{ selectedOrder.diagnostic_report_status }}
 				</Badge>
 			</div>
@@ -96,7 +96,7 @@
 					</div>
 
 					<!-- Order Status -->
-					<Button v-if="selectedOrder.invoice" :ref_for="true" theme="gray" size="sm"
+					<Button v-if="selectedOrder.invoice?.length" :ref_for="true" theme="gray" size="sm"
 						@click="print('Sales Invoice', selectedOrder.invoice)">
 						<Tooltip :text="'Print Invoice'" placement="top">
 							<slot name="icon">
@@ -124,14 +124,51 @@
 			<div class="mt-6">
 				<div class="flex items-center justify-between gap-2 py-2">
 					<h3 class="text-lg font-semibold text-gray-900">Test Report Details</h3>
-					<Button v-if="selectedOrder.diagnostic_report_status && selectedOrder.diagnostic_report_status != 'Open'" :ref_for="true" theme="gray" size="sm"
-						@click="print('Diagnostic Report', selectedOrder.diagnostic_report)">
+					<Button
+						v-if="printableDiagnosticReports.length"
+						:ref_for="true"
+						theme="gray"
+						size="sm"
+						@click="print('Diagnostic Report', printableDiagnosticReports.map((report) => report.name))">
 						<Tooltip :text="'Print Report'" placement="top">
 							<slot name="icon">
 								<FeatherIcon :name="'printer'" class="size-3 text-ink-white-7" />
 							</slot>
 						</Tooltip>
 					</Button>
+				</div>
+				<div v-if="selectedOrder.diagnostic_reports?.length" class="mb-4 flex flex-wrap gap-2">
+					<div
+						v-for="report in selectedOrder.diagnostic_reports"
+						:key="report.name"
+						class="flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2"
+					>
+						<div>
+							<p class="text-sm font-medium text-gray-800">{{ report.observation_category }}</p>
+							<p class="text-xs text-gray-500">{{ report.name }}</p>
+						</div>
+						<Badge
+							v-if="report.status"
+							:variant="'outline'"
+							size="sm"
+							:theme="getStatusColor(report.status)"
+						>
+							{{ report.status }}
+						</Badge>
+						<Button
+							v-if="report.status && report.status != 'Open'"
+							:ref_for="true"
+							theme="gray"
+							size="sm"
+							@click="print('Diagnostic Report', report.name)"
+						>
+							<Tooltip :text="'Print Report'" placement="top">
+								<slot name="icon">
+									<FeatherIcon :name="'printer'" class="size-3 text-ink-white-7" />
+								</slot>
+							</Tooltip>
+						</Button>
+					</div>
 				</div>
 				<div class="space-y-2 max-h-[60vh] overflow-y-auto pr-2">
 					<div v-for="(order, index) in selectedOrder.tests" :key="index"
@@ -279,6 +316,12 @@ const paginatedOrders = computed(() => {
 	const start = (currentPage.value - 1) * pageSize;
 	return orders.value.slice(start, start + pageSize);
 });
+
+const printableDiagnosticReports = computed(() =>
+	(selectedOrder.value?.diagnostic_reports || []).filter(
+		(report) => report.status && report.status !== "Open"
+	)
+);
 
 function print(doctype, docname) {
 	let get_print_format = createResource({

--- a/patient_portal/src/components/DiagnosticModel.vue
+++ b/patient_portal/src/components/DiagnosticModel.vue
@@ -156,7 +156,7 @@
 							{{ report.status }}
 						</Badge>
 						<Button
-							v-if="report.status && report.status != 'Open'"
+							v-if="report.status && report.status !== 'Open'"
 							:ref_for="true"
 							theme="gray"
 							size="sm"


### PR DESCRIPTION
PR Description

Summary
This PR changes diagnostic report generation to create separate Diagnostic Report records per observation category for the same invoice or encounter, without adding any new fields.

The implementation uses the existing hidden Diagnostic Report.title field to distinguish category-specific reports internally.

Problem
Diagnostic reports were previously generated as a single record per invoice or encounter, which caused Imaging, Laboratory, and other observation categories to be grouped together in one report.

Fix:-
- create and resolve Diagnostic Report records per observation category
- filter report contents by the matching category
- keep report status updates category-specific
- update patient portal APIs and UI to support multiple reports per order
- update sample collection cleanup to handle multiple linked reports safely

Files Changed
1)healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
Added helpers to encode/decode category information in title and scoped report validation/status logic by category.

2)healthcare/healthcare/doctype/observation/observation.py
Updated report lookup and observation detail loading to resolve the correct category-specific report.

3)healthcare/healthcare/utils.py
Updated invoice-side diagnostic report generation to create one report per observation category.

4)healthcare/healthcare/doctype/service_request/service_request.py
Updated encounter/service-request report generation to reuse/create reports category-wise.

5)healthcare/healthcare/api/patient_portal.py
Updated portal aggregation to return multiple diagnostic reports per order.

6)patient_portal/src/components/DiagnosticModel.vue
Updated the portal UI to display and print multiple category-wise reports.

7)healthcare/healthcare/doctype/sample_collection/sample_collection.py
Updated cleanup logic to handle multiple linked diagnostic reports.

8)healthcare/healthcare/doctype/observation/test_observation.py
Added regression coverage for category-specific report filtering and status updates.

Check below images for reference
<img width="980" height="64" alt="image" src="https://github.com/user-attachments/assets/603c98fa-2c67-4c25-9bd7-7f90f53db800" />

<img width="943" height="74" alt="image" src="https://github.com/user-attachments/assets/ab19ea8a-cb53-47d9-b216-80f1c596f95c" />

no-docs