### PR TITLE
fix: continue billing other items if item is not configured for service unit

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
@@ -533,9 +533,7 @@ let transfer_for_procedure_dialog = function (frm) {
 			if (check_in > frappe.datetime.now_datetime()) {
 				frappe.msgprint({
 					title: __("Not Allowed"),
-					message: __(
-						"Check-in time cannot be greater than the current time",
-					),
+					message: __("Check-in time cannot be after current time"),
 					indicator: "red",
 				});
 				return;

--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -183,6 +183,8 @@ class InpatientRecord(Document):
 			)[0]
 
 			for inpatient in ip_records:
+				if not inpatient.get("item"):
+					continue
 				item_name, stock_uom = frappe.db.get_value(
 					"Item", inpatient.get("item"), ["item_name", "stock_uom"]
 				)


### PR DESCRIPTION
- continue billing other items if item is not configured for service unit
- error message 