### PR TITLE
fix: separate diagnostic reports by observation category

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -20,6 +20,7 @@
   "naming_series",
   "ref_doctype",
   "docname",
+  "observation_category",
   "sales_invoice_status",
   "reference_posting_date",
   "sample_collection",
@@ -66,6 +67,15 @@
    "in_standard_filter": 1,
    "label": "Ref DocName",
    "options": "ref_doctype",
+   "read_only": 1
+  },
+  {
+   "fieldname": "observation_category",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "in_standard_filter": 1,
+   "label": "Observation Category",
+   "options": "\nSocial History\nVital Signs\nImaging\nLaboratory\nProcedure\nSurvey\nExam\nTherapy\nActivity",
    "read_only": 1
   },
   {

--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -136,19 +136,26 @@ class Observation(Document):
 
 @frappe.whitelist()
 def get_observation_details(docname):
-	reference = frappe.get_value("Diagnostic Report", docname, ["docname", "ref_doctype"], as_dict=True)
+	reference = frappe.get_value(
+		"Diagnostic Report", docname, ["docname", "ref_doctype", "observation_category"], as_dict=True
+	)
 	observation = []
+	observation_category = reference.get("observation_category")
 
 	if reference.get("ref_doctype") == "Sales Invoice":
+		filters = {
+			"sales_invoice": reference.get("docname"),
+			"parent_observation": "",
+			"status": ["!=", "Cancelled"],
+			"docstatus": ["!=", 2],
+		}
+		if observation_category:
+			filters["observation_category"] = observation_category
+
 		observation = frappe.get_list(
 			"Observation",
 			fields=["*"],
-			filters={
-				"sales_invoice": reference.get("docname"),
-				"parent_observation": "",
-				"status": ["!=", "Cancelled"],
-				"docstatus": ["!=", 2],
-			},
+			filters=filters,
 			order_by="creation",
 		)
 	elif reference.get("ref_doctype") == "Patient Encounter":
@@ -163,15 +170,19 @@ def get_observation_details(docname):
 			order_by="creation",
 			pluck="name",
 		)
+		filters = {
+			"service_request": ["in", service_requests],
+			"parent_observation": "",
+			"status": ["!=", "Cancelled"],
+			"docstatus": ["!=", 2],
+		}
+		if observation_category:
+			filters["observation_category"] = observation_category
+
 		observation = frappe.get_list(
 			"Observation",
 			fields=["*"],
-			filters={
-				"service_request": ["in", service_requests],
-				"parent_observation": "",
-				"status": ["!=", "Cancelled"],
-				"docstatus": ["!=", 2],
-			},
+			filters=filters,
 			order_by="creation",
 		)
 
@@ -530,7 +541,13 @@ def set_diagnostic_report_status(doc):
 			)
 
 		diagnostic_report = frappe.db.get_value(
-			"Diagnostic Report", {"ref_doctype": ref_doctype, "docname": ref_docname}, "name"
+			"Diagnostic Report",
+			{
+				"ref_doctype": ref_doctype,
+				"docname": ref_docname,
+				"observation_category": doc.observation_category,
+			},
+			"name",
 		)
 
 		if diagnostic_report:

--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -135,7 +135,7 @@ class Observation(Document):
 
 
 @frappe.whitelist()
-def get_observation_details(docname):
+def get_observation_details(docname: str):
 	reference = frappe.get_value(
 		"Diagnostic Report", docname, ["docname", "ref_doctype", "observation_category"], as_dict=True
 	)

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -344,9 +344,20 @@ def make_observation(service_request, appointment=None):
 		else:
 			observation = create_observation(service_request, appointment)
 
-	diagnostic_report = frappe.db.exists("Diagnostic Report", {"docname": service_request.order_group})
+	diagnostic_report = frappe.db.exists(
+		"Diagnostic Report",
+		{
+			"ref_doctype": service_request.source_doc,
+			"docname": service_request.order_group,
+			"observation_category": template.observation_category,
+		},
+	)
 	if not diagnostic_report:
-		insert_diagnostic_report(service_request, sample_collection.name if sample_collection else None)
+		insert_diagnostic_report(
+			service_request,
+			sample_collection.name if sample_collection else None,
+			template.observation_category,
+		)
 
 	if sample_collection:
 		if diagnostic_report and not frappe.db.get_value(
@@ -401,12 +412,13 @@ def create_observation(service_request, appointment=None):
 	return doc
 
 
-def insert_diagnostic_report(doc, sample_collection=None):
+def insert_diagnostic_report(doc, sample_collection=None, observation_category=None):
 	diagnostic_report = frappe.new_doc("Diagnostic Report")
 	diagnostic_report.company = doc.company
 	diagnostic_report.patient = doc.patient
 	diagnostic_report.ref_doctype = doc.source_doc
 	diagnostic_report.docname = doc.order_group
+	diagnostic_report.observation_category = observation_category
 	diagnostic_report.practitioner = doc.practitioner
 	diagnostic_report.sample_collection = sample_collection
 	diagnostic_report.save(ignore_permissions=True)

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -231,7 +231,7 @@ def make_lab_test(service_request):
 
 
 @frappe.whitelist()
-def make_observation(service_request, appointment=None):
+def make_observation(service_request: str, appointment: str | None = None):
 	if not service_request:
 		return
 

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1556,6 +1556,7 @@ def create_sample_collection_and_observation(doc):
 				"sample_qty",
 				"has_component",
 				"sample_collection_required",
+				"observation_category",
 			],
 			as_dict=True,
 		)
@@ -1578,6 +1579,7 @@ def create_sample_collection_and_observation(doc):
 			patient = grp
 		if meta.has_field("patient"):
 			sample_collection = create_sample_collection(doc, patient)
+			observation_categories = set()
 			for obs in out_data[grp]:
 				(
 					sample_collection,
@@ -1585,11 +1587,16 @@ def create_sample_collection_and_observation(doc):
 				) = insert_observation_and_sample_collection(
 					doc, patient, obs, sample_collection, obs.get("child")
 				)
+				if diag_report_required and obs.get("observation_category"):
+					observation_categories.add(obs.get("observation_category"))
 			if sample_collection and len(sample_collection.get("observation_sample_collection")) > 0:
 				sample_collection.save(ignore_permissions=True)
 
 			if diag_report_required:
-				insert_diagnostic_report(doc, patient, sample_collection.name)
+				for observation_category in observation_categories:
+					insert_diagnostic_report(
+						doc, patient, sample_collection.name, observation_category
+					)
 		else:
 			sample_collection, diag_report_required = insert_observation_and_sample_collection(
 				doc, patient, grp, sample_collection
@@ -1600,7 +1607,9 @@ def create_sample_collection_and_observation(doc):
 			sample_collection.save(ignore_permissions=True)
 
 		if diag_report_required:
-			insert_diagnostic_report(doc, patient, sample_collection.name)
+			insert_diagnostic_report(
+				doc, patient, sample_collection.name, grp.get("observation_category")
+			)
 
 
 def create_sample_collection(doc, patient):
@@ -1616,13 +1625,21 @@ def create_sample_collection(doc, patient):
 	return sample_collection
 
 
-def insert_diagnostic_report(doc, patient, sample_collection=None):
-	if not frappe.db.exists("Diagnostic Report", {"docname": doc.name}):
+def insert_diagnostic_report(doc, patient, sample_collection=None, observation_category=None):
+	if not frappe.db.exists(
+		"Diagnostic Report",
+		{
+			"ref_doctype": doc.doctype,
+			"docname": doc.name,
+			"observation_category": observation_category,
+		},
+	):
 		diagnostic_report = frappe.new_doc("Diagnostic Report")
 		diagnostic_report.company = doc.company
 		diagnostic_report.patient = patient
 		diagnostic_report.ref_doctype = doc.doctype
 		diagnostic_report.docname = doc.name
+		diagnostic_report.observation_category = observation_category
 		diagnostic_report.practitioner = doc.ref_practitioner
 		diagnostic_report.sample_collection = sample_collection
 		diagnostic_report.save(ignore_permissions=True)

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1594,9 +1594,7 @@ def create_sample_collection_and_observation(doc):
 
 			if diag_report_required:
 				for observation_category in observation_categories:
-					insert_diagnostic_report(
-						doc, patient, sample_collection.name, observation_category
-					)
+					insert_diagnostic_report(doc, patient, sample_collection.name, observation_category)
 		else:
 			sample_collection, diag_report_required = insert_observation_and_sample_collection(
 				doc, patient, grp, sample_collection
@@ -1607,9 +1605,7 @@ def create_sample_collection_and_observation(doc):
 			sample_collection.save(ignore_permissions=True)
 
 		if diag_report_required:
-			insert_diagnostic_report(
-				doc, patient, sample_collection.name, grp.get("observation_category")
-			)
+			insert_diagnostic_report(doc, patient, sample_collection.name, grp.get("observation_category"))
 
 
 def create_sample_collection(doc, patient):


### PR DESCRIPTION
This change makes Diagnostic Report unique per ref_doctype + docname + observation_category instead of effectively per reference document only. It prevents different categories for the same invoice or encounter from collapsing into one report.
It also updates report lookup and rendering so each report only tracks and prints observations from its own category. 

Changes:-
1.Added the new observation_category field (hidden) on Diagnostic Report so the category can be stored and used in lookups.
2.Included observation_category when loading observation template data, changed Diagnostic Report existence checks to include category, and created reports per category in the invoice-driven flow.
3.Updated encounter/service-request report creation to pass the template’s observation_category and to check for an existing report using the category-aware key.
4.Filtered get_observation_details by the report’s observation_category, and changed Diagnostic Report lookup during observation status updates to include the observation’s category.