### PR TITLE
Fix linked item auto-population in Medication form

### DIFF
--- a/healthcare/healthcare/doctype/medication_linked_item/medication_linked_item.json
+++ b/healthcare/healthcare/doctype/medication_linked_item/medication_linked_item.json
@@ -21,6 +21,7 @@
  ],
  "fields": [
   {
+   "fetch_from": "item.brand",
    "fieldname": "brand",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -28,6 +29,7 @@
    "options": "Brand"
   },
   {
+   "fetch_from": "item.default_item_manufacturer",
    "fieldname": "manufacturer",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -51,6 +53,7 @@
    "set_only_once": 1
   },
   {
+   "fetch_from": "item.item_group",
    "fieldname": "item_group",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -92,6 +95,7 @@
    "label": "Change In Item"
   },
   {
+   "fetch_from": "item.description",
    "fieldname": "description",
    "fieldtype": "Small Text",
    "label": "Description"
@@ -100,7 +104,7 @@
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2026-02-20 19:22:29.335838",
+ "modified": "2026-05-20 15:28:50.678477",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Medication Linked Item",


### PR DESCRIPTION
Issue:
Selecting an existing Item in the linked_items child table of the Medication form did not auto-populate dependent fields like item_group, brand, manufacturer, description.

PR description:
This change fixes the Medication Linked Item child table so selecting an Item correctly pulls related values from the linked Item master.

Changes made:
Added fetch_from for item_group
Added fetch_from for brand
Added fetch_from for manufacturer ( will be fetched if the manufacturer is added in the item manufacturer form and set it as default)
Added fetch_from for description

The child table fields were missing fetch_from mappings, so Frappe had no field-level instructions to copy values from the selected Item. With these mappings in place, the form now auto-fills the expected details when an item is selected.

<img width="942" height="191" alt="image" src="https://github.com/user-attachments/assets/965c1b20-9e50-4955-99e5-909732ffdb61" />
