### PR TITLE
Fix: Exclude OT service unit types from normal Transfer Inpatient flow

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.js
@@ -421,6 +421,7 @@ let transfer_patient_dialog = function (frm) {
 			filters: {
 				inpatient_occupancy: 1,
 				allow_appointments: 0,
+				is_ot: 0,
 			},
 		};
 	};


### PR DESCRIPTION
Issue:-
In the Transfer Patient dialog for the normal inpatient transfer flow, the Service Unit Type link was filtered only by:
- inpatient_occupancy = 1
- allow_appointments = 0

Because of that, OT service unit types were also shown in the normal transfer list if they matched those conditions.
This was incorrect because OT should only be available in the procedure transfer flow, not in the standard room/ward transfer flow.

Fix:-
Updated the normal transfer dialog query in inpatient_record.js to also apply:
       is_ot = 0

So now the behavior is:
Normal transfer: shows only non-OT inpatient occupancy service unit types
Transfer for procedure: continues to show only OT service unit types via is_ot = 1

This change fixes the service unit type filtering in the normal inpatient transfer dialog.
Previously, OT service unit types appeared in the standard Transfer Patient flow because the query did not explicitly exclude OT. That created overlap between the normal transfer flow and the procedure transfer flow.
With this update, the normal transfer flow now excludes OT by adding is_ot: 0 to the Service Unit Type query. The existing procedure transfer flow remains unchanged and continues to use OT-only filtering.

<img width="545" height="398" alt="image" src="https://github.com/user-attachments/assets/f029352b-62d4-4fa1-ac1e-1f6434293b89" />
