### PR TITLE
fix: support Diagnostic Report creation for manual Observation Service Requests

### DIFF
--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -144,7 +144,7 @@ class Observation(Document):
 
 
 @frappe.whitelist()
-def get_observation_details(docname):
+def get_observation_details(docname: str):
 	reference = frappe.get_value("Diagnostic Report", docname, ["docname", "ref_doctype"], as_dict=True)
 	observation = []
 

--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -183,6 +183,18 @@ def get_observation_details(docname):
 			},
 			order_by="creation",
 		)
+	elif reference.get("ref_doctype") == "Service Request":
+		observation = frappe.get_list(
+			"Observation",
+			fields=["*"],
+			filters={
+				"service_request": reference.get("docname"),
+				"parent_observation": "",
+				"status": ["!=", "Cancelled"],
+				"docstatus": ["!=", 2],
+			},
+			order_by="creation",
+		)
 
 	out_data, obs_length = aggregate_and_return_observation_data(observation)
 

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -396,6 +396,7 @@ def create_observation(service_request, appointment=None):
 	ref_doctype, ref_docname = get_service_request_reference(service_request)
 	doc = frappe.new_doc("Observation")
 	doc.posting_datetime = now_datetime()
+	doc.company = service_request.company
 	doc.patient = service_request.patient
 	doc.appointment = appointment
 	doc.observation_template = service_request.template_dn

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -236,6 +236,7 @@ def make_observation(service_request, appointment=None):
 		return
 
 	service_request = frappe.get_cached_doc("Service Request", service_request)
+	ref_doctype, ref_docname = get_service_request_reference(service_request)
 
 	if (
 		frappe.db.get_single_value("Healthcare Settings", "process_service_request_only_if_paid")
@@ -344,7 +345,9 @@ def make_observation(service_request, appointment=None):
 		else:
 			observation = create_observation(service_request, appointment)
 
-	diagnostic_report = frappe.db.exists("Diagnostic Report", {"docname": service_request.order_group})
+	diagnostic_report = frappe.db.exists(
+		"Diagnostic Report", {"ref_doctype": ref_doctype, "docname": ref_docname}
+	)
 	if not diagnostic_report:
 		insert_diagnostic_report(service_request, sample_collection.name if sample_collection else None)
 
@@ -361,14 +364,15 @@ def make_observation(service_request, appointment=None):
 
 
 def create_sample_collection(patient, service_request, appointment=None, template=None):
+	ref_doctype, ref_docname = get_service_request_reference(service_request)
 	sample_collection = frappe.new_doc("Sample Collection")
 	sample_collection.patient = patient.name
 	sample_collection.patient_age = patient.get_age()
 	sample_collection.patient_sex = patient.sex
 	sample_collection.appointment = appointment
 	sample_collection.company = service_request.company
-	sample_collection.reference_doc = service_request.source_doc
-	sample_collection.reference_name = service_request.order_group
+	sample_collection.reference_doc = ref_doctype
+	sample_collection.reference_name = ref_docname
 	if template:
 		sample_collection.append(
 			"observation_sample_collection",
@@ -389,27 +393,36 @@ def create_sample_collection(patient, service_request, appointment=None, templat
 
 
 def create_observation(service_request, appointment=None):
+	ref_doctype, ref_docname = get_service_request_reference(service_request)
 	doc = frappe.new_doc("Observation")
 	doc.posting_datetime = now_datetime()
 	doc.patient = service_request.patient
 	doc.appointment = appointment
 	doc.observation_template = service_request.template_dn
-	doc.reference_doctype = "Patient Encounter"
-	doc.reference_docname = service_request.order_group
+	doc.reference_doctype = ref_doctype
+	doc.reference_docname = ref_docname
 	doc.service_request = service_request.name
 	doc.insert()
 	return doc
 
 
 def insert_diagnostic_report(doc, sample_collection=None):
+	ref_doctype, ref_docname = get_service_request_reference(doc)
 	diagnostic_report = frappe.new_doc("Diagnostic Report")
 	diagnostic_report.company = doc.company
 	diagnostic_report.patient = doc.patient
-	diagnostic_report.ref_doctype = doc.source_doc
-	diagnostic_report.docname = doc.order_group
+	diagnostic_report.ref_doctype = ref_doctype
+	diagnostic_report.docname = ref_docname
 	diagnostic_report.practitioner = doc.practitioner
 	diagnostic_report.sample_collection = sample_collection
 	diagnostic_report.save(ignore_permissions=True)
+
+
+def get_service_request_reference(service_request):
+	if service_request.source_doc and service_request.order_group:
+		return service_request.source_doc, service_request.order_group
+
+	return "Service Request", service_request.name
 
 
 def check_observation_sample_exist(service_request):

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -231,7 +231,7 @@ def make_lab_test(service_request):
 
 
 @frappe.whitelist()
-def make_observation(service_request, appointment=None):
+def make_observation(service_request: str, appointment: str | None = None):
 	if not service_request:
 		return
 

--- a/healthcare/healthcare/doctype/service_request/test_service_request.py
+++ b/healthcare/healthcare/doctype/service_request/test_service_request.py
@@ -11,10 +11,10 @@ from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings impor
 	get_receivable_account,
 )
 from healthcare.healthcare.doctype.lab_test.test_lab_test import create_lab_test
+from healthcare.healthcare.doctype.observation.observation import get_observation_details
 from healthcare.healthcare.doctype.patient_encounter.patient_encounter import (
 	create_patient_referral,
 )
-from healthcare.healthcare.doctype.observation.observation import get_observation_details
 from healthcare.healthcare.doctype.service_request.service_request import (
 	make_clinical_procedure,
 	make_observation,

--- a/healthcare/healthcare/doctype/service_request/test_service_request.py
+++ b/healthcare/healthcare/doctype/service_request/test_service_request.py
@@ -14,7 +14,11 @@ from healthcare.healthcare.doctype.lab_test.test_lab_test import create_lab_test
 from healthcare.healthcare.doctype.patient_encounter.patient_encounter import (
 	create_patient_referral,
 )
-from healthcare.healthcare.doctype.service_request.service_request import make_clinical_procedure
+from healthcare.healthcare.doctype.observation.observation import get_observation_details
+from healthcare.healthcare.doctype.service_request.service_request import (
+	make_clinical_procedure,
+	make_observation,
+)
 from healthcare.healthcare.doctype.therapy_plan.test_therapy_plan import create_therapy_plan
 from healthcare.tests.utils import HealthcareTestSuite
 
@@ -147,6 +151,50 @@ class TestServiceRequest(HealthcareTestSuite):
 			),
 			practitioner_2,
 		)
+
+	def test_manual_observation_service_request_creates_diagnostic_report(self):
+		patient = frappe.get_list("Patient", pluck="name")[0]
+		practitioner = frappe.get_list("Healthcare Practitioner", pluck="name")[0]
+		obs_template = frappe.get_doc("Observation Template", "_Test Observation without Sample")
+
+		service_request = frappe.get_doc(
+			{
+				"doctype": "Service Request",
+				"order_date": getdate(),
+				"order_time": nowtime(),
+				"company": "_Test Company",
+				"patient": patient,
+				"practitioner": practitioner,
+				"template_dt": "Observation Template",
+				"template_dn": obs_template.name,
+				"quantity": 1,
+			}
+		)
+		service_request.insert()
+		service_request.submit()
+
+		create_sales_invoice(patient, service_request, obs_template, "observation")
+		observation_name, doctype = make_observation(service_request.name)
+
+		self.assertEqual(doctype, "Observation")
+		self.assertTrue(
+			frappe.db.exists(
+				"Diagnostic Report",
+				{"ref_doctype": "Service Request", "docname": service_request.name},
+			)
+		)
+
+		observation = frappe.get_doc("Observation", observation_name)
+		self.assertEqual(observation.reference_doctype, "Service Request")
+		self.assertEqual(observation.reference_docname, service_request.name)
+
+		report_name = frappe.db.get_value(
+			"Diagnostic Report",
+			{"ref_doctype": "Service Request", "docname": service_request.name},
+			"name",
+		)
+		_, obs_length = get_observation_details(report_name)
+		self.assertEqual(obs_length, 1)
 
 
 def create_encounter(


### PR DESCRIPTION
This fixes a mismatch between two observation flows:
        - Patient Encounter -> Service Request -> Observation -> Diagnostic Report
        - Manual Service Request -> Invoice -> Observation

Previously, encounter-created service requests generated diagnostic reports correctly, but manually created observation service requests did not. In the manual flow, Create Observation could create the observation, but the diagnostic report was not created.

The root cause was that the observation/report flow assumed every observation service request came from a Patient Encounter and depended on source_doc and order_group. That works for encounter-generated requests, but manual service requests often do not have those fields populated.

This fix adds a fallback reference for manual service requests:
      - if source_doc and order_group exist, existing behavior is preserved
      - otherwise, the system uses the Service Request itself as the diagnostic reference

Changes included:
1)service_request.py
added get_service_request_reference()
updated observation, sample collection, and diagnostic report creation to use the resolved reference

2)observation.py
added support for diagnostic reports linked directly to Service Request

3)test_service_request.py
added a regression test for the manual flow

Result (After fix):
    - encounter-based behavior stays unchanged
    - manual observation service requests now generate and resolve diagnostic reports correctly