### PR TITLE
fix: resolve type hint issue in make_material_receipt submit parameter

### DIFF
--- a/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.py
+++ b/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.py
@@ -240,7 +240,7 @@ class ClinicalProcedure(Document):
 		return True
 
 	@frappe.whitelist()
-	def make_material_receipt(self, submit: bool = False) -> dict:
+	def make_material_receipt(self, submit: bool | None = False) -> dict:
 		stock_entry = frappe.new_doc("Stock Entry")
 
 		stock_entry.stock_entry_type = "Material Receipt"


### PR DESCRIPTION
- Allow `submit` to be null when omitted by the client, preventing Pydantic type validation errors.