### PR TITLE
Fix Healthcare Service Unit Type rate edit failing due to wrong item code mapping

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.json
+++ b/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.json
@@ -106,7 +106,7 @@
    "read_only": 1
   },
   {
-   "fetch_from": "item.item_name",
+   "fetch_from": "item.item_code",
    "fieldname": "item_code",
    "fieldtype": "Data",
    "hide_days": 1,


### PR DESCRIPTION
Issue:-
Editing the rate of an existing billable Healthcare Service Unit Type was throwing an error like 
                  Could not find Item Code: Semi PVT Mezzanine Floor.
      
<img width="711" height="233" alt="image" src="https://github.com/user-attachments/assets/12b267dc-9c8b-4b05-8a2c-1b667b72ceda" />

The issue was caused by the item_code field fetching its value from item.item_name.
Because of this, the document was using the Item Name instead of the actual Item Code during save/update flows.

When the rate was edited, the system attempted to resolve the item using a display name, which caused the item code lookup to fail.

Fix Applied
Changed fetch_from from item.item_name to item.item_code.
