### PR TITLE
fix(medication): don't disable non-billable stock/purchase linked Items

### DIFF
--- a/healthcare/healthcare/doctype/medication/medication.py
+++ b/healthcare/healthcare/doctype/medication/medication.py
@@ -77,7 +77,17 @@ class Medication(Document):
 								item_price.price_list = self.price_list
 								item_price.save()
 				else:
-					frappe.db.set_value("Item", item.item_code, "disabled", 1)
+					# "Not separately billable" must not deactivate an Item that is
+					# used in other flows. A linked Item can be a non-billable
+					# stock/purchase consumable (e.g. a vaccine received via Purchase
+					# Receipt and issued per dose, while the patient is billed through
+					# a separate service Item). Only disable Items that aren't
+					# transactable elsewhere.
+					item_flags = frappe.db.get_value(
+						"Item", item.item_code, ["is_stock_item", "is_purchase_item"], as_dict=True
+					)
+					if item_flags and not item_flags.is_stock_item and not item_flags.is_purchase_item:
+						frappe.db.set_value("Item", item.item_code, "disabled", 1)
 
 				frappe.db.set_value("Medication Linked Item", item.name, "change_in_item", 0)
 		self.reload()
@@ -100,7 +110,10 @@ def insert_item(doc, item):
 				"description": item.item_code,
 				"is_sales_item": 1,
 				"is_stock_item": 1,
-				"disabled": 0 if item.is_billable and not doc.disabled else 1,
+				# The Item created here is a stock item; don't disable it merely
+				# because the linked row isn't separately billable — only honour the
+				# parent Medication's own disabled state.
+				"disabled": 1 if doc.disabled else 0,
 				"stock_uom": item.stock_uom or frappe.db.get_single_value("Stock Settings", "stock_uom"),
 			}
 		)


### PR DESCRIPTION
Problem 
Medication ties the disabled state of each linked Item to that row’s is_billable flag, conflating two independent concepts — “not separately billable” and “inactive”. On both insert and update, a linked Item whose is_billable is unchecked is set to disabled = 1, deactivating Items that are valid and in active use in other flows (purchasing, stock). 
This makes it impossible to model a medication whose linked Item is a non-billable stock consumable — e.g. a vaccine purchased as a batch-tracked stock item (entered via Purchase Receipt, issued per dose) while the patient is billed through a separate service Item. The consumable is re-disabled on every Medication save, disappears from Item pickers, and cannot be transacted at all (a disabled Item is rejected by Stock Entry / Purchase Receipt). 

Steps to reproduce 
Item VAC-X: Maintain Stock = 1, Has Batch No = 1, Allow Sales = 0.
Item SVC-X: a service Item (Maintain Stock = 0, Allow Sales = 1).
Medication with both in Linked Items: VAC-X with Is Billable = 0, SVC-X with Is Billable = 1. Save.
VAC-X becomes disabled = 1. 

Fix 
Only disable linked Items that aren’t transactable elsewhere: skip is_stock_item / is_purchase_item Items in the update path, and on the insert path honour just the parent Medication’s own disabled state (the Item created there is always a stock item). This preserves the original intent — hiding a non billable, Medication-owned service Item from billing — without breaking shared stock/purchase Items. 
```

# update_item_and_item_price() — before
else:
frappe.db.set_value("Item", item.item_code, "disabled", 1)
 # after
else:
item_flags = frappe.db.get_value(
"Item", item.item_code, ["is_stock_item", "is_purchase_item"], as_dict=True
)
if item_flags and not item_flags.is_stock_item and not item_flags.is_purchase_item:
frappe.db.set_value("Item", item.item_code, "disabled", 1)
```

No DocType/schema changes; behaviour for plain non-stock service Items is unchanged