### PR TITLE
fix: prevent future DOB selection for patients

### DIFF
--- a/healthcare/healthcare/doctype/patient/patient.js
+++ b/healthcare/healthcare/doctype/patient/patient.js
@@ -4,6 +4,8 @@
 
 frappe.ui.form.on('Patient', {
 	refresh: function (frm) {
+		set_dob_max_date(frm);
+
 		frm.set_query('patient', 'patient_relation', function () {
 			return {
 				filters: [
@@ -56,6 +58,8 @@ frappe.ui.form.on('Patient', {
 	},
 
 	onload: function (frm) {
+		set_dob_max_date(frm);
+
 		if (frm.doc.dob) {
 			$(frm.fields_dict['age_html'].wrapper).html(`${__('AGE')} : ${get_age(frm.doc.dob)}`);
 		} else {
@@ -63,6 +67,10 @@ frappe.ui.form.on('Patient', {
 		}
 	}
 });
+
+let set_dob_max_date = function (frm) {
+	frm.fields_dict.dob.datepicker?.update({ maxDate: new Date() });
+};
 
 frappe.ui.form.on('Patient', 'dob', function(frm) {
 	if (frm.doc.dob) {

--- a/healthcare/public/js/patient_quick_entry.js
+++ b/healthcare/public/js/patient_quick_entry.js
@@ -23,6 +23,8 @@ frappe.ui.form.PatientQuickEntryForm = class PatientQuickEntryForm extends (
 		this.mandatory.splice(3, 0, ...custom_fields);
 
 		super.render_dialog();
+
+		this.dialog?.fields_dict?.dob?.datepicker?.update({ maxDate: new Date() });
 	}
 
 	get_standard_fields() {


### PR DESCRIPTION
<img width="1024" height="866" alt="Screenshot 2026-06-09 211132" src="https://github.com/user-attachments/assets/41e65e2f-3c18-4e74-9710-5f87a1ca7b86" />



Prevent selecting future dates in the Patient DOB field by restricting the date picker in both the Patient form and Patient Quick Entry dialog.

no-docs