### PR TITLE
Fix Order Template Type dropdown in Service Request to selection only

### DIFF
--- a/healthcare/healthcare/doctype/service_request/service_request.js
+++ b/healthcare/healthcare/doctype/service_request/service_request.js
@@ -56,6 +56,7 @@ frappe.ui.form.on("Service Request", {
 				},
 			};
 		});
+		frm.set_df_property("template_dt", "only_select", true);
 
 		frm.set_query("status", function () {
 			return {

--- a/healthcare/public/js/healthcare_note.js
+++ b/healthcare/public/js/healthcare_note.js
@@ -276,6 +276,7 @@ healthcare.Orders = class Orders {
 						fieldname: "order_template_type",
 						fieldtype: "Link",
 						options: "DocType",
+						only_select: true,
 						reqd: 1,
 						get_query: () => {
 							let order_template_doctypes = [


### PR DESCRIPTION
Issue description: 
In the Service Request flow, the Order Template Type field is implemented as a Link to DocType and filtered to a supported set of template doctypes. Because it behaves like a generic Link field, the dropdown was showing Create a new DocType, which is misleading for end users and not part of the intended workflow. Users should only be able to choose from the allowed template doctypes.
<img width="498" height="403" alt="image" src="https://github.com/user-attachments/assets/80bbc8da-26e4-4211-88d1-32a8ce7de77f" />

Fix applied: Updated the Order Template Type field behavior to use only_select in both service_request.js and healthcare_note.js files.

This keeps the field limited to the supported doctypes and removes the Create a new DocType option from the dropdown as shown in below image
<img width="549" height="400" alt="image" src="https://github.com/user-attachments/assets/58a44577-cdaf-4556-b75a-3680701c3af8" />
