### PR TITLE
fix(insurance): prevent users from creating DocTypes from Item Insurance Eligibility healthcare service field

### DIFF
--- a/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.js
+++ b/healthcare/healthcare/doctype/item_insurance_eligibility/item_insurance_eligibility.js
@@ -35,6 +35,7 @@ frappe.ui.form.on("Item Insurance Eligibility", {
 				},
 			};
 		});
+		frm.set_df_property("template_dt", "only_select", true);
 
 		frm.set_query("template_dn", function () {
 			if (frm.doc.template_dt != "Appointment Type") {


### PR DESCRIPTION
Issue description: 
In Item Insurance Eligibility, when Eligibility For is set to Service, the Healthcare Service field shows Create a new DocType in the dropdown. That field is meant only for selecting from a predefined set of allowed service template doctypes, and creating a new DocType from there is not recommended for users in this flow. Showing that action is misleading and can lead to confusion.

Before fix:
<img width="470" height="442" alt="image" src="https://github.com/user-attachments/assets/0a905e6b-cf8f-4cb2-a65f-761d7506edb8" />


Fix applied:
Updated item_insurance_eligibility.js to set only_select on template_dt. This keeps the filtered allowed options intact and removes the Create a new DocType action, so users can only select from the intended service templates.

After fix: 
<img width="501" height="466" alt="image" src="https://github.com/user-attachments/assets/3c4d0fdd-ada3-4879-9668-3613bfc5e189" />
