### PR TITLE
fix(patient-encounter): filter Patient Encounter observation template to billable templates

### DIFF
--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -205,13 +205,7 @@ frappe.ui.form.on("Patient Encounter", {
 			};
 		});
 
-		frm.set_query("lab_test_code", "lab_test_prescription", function () {
-			return {
-				filters: {
-					is_billable: 1,
-				},
-			};
-		});
+		set_lab_test_prescription_queries(frm);
 
 		frm.set_query("appointment", function () {
 			return {
@@ -704,13 +698,7 @@ let create_nursing_tasks = function (frm) {
 			});
 
 			d.hide();
-			frm.set_query("lab_test_code", "lab_test_prescription", function () {
-				return {
-					filters: {
-						is_billable: 1,
-					},
-				};
-			});
+			set_lab_test_prescription_queries(frm);
 		},
 	});
 
@@ -857,6 +845,24 @@ var apply_code_sm_filter_to_child = function (frm, field, table_list, code_syste
 				},
 			};
 		});
+	});
+};
+
+var set_lab_test_prescription_queries = function (frm) {
+	frm.set_query("lab_test_code", "lab_test_prescription", function () {
+		return {
+			filters: {
+				is_billable: 1,
+			},
+		};
+	});
+
+	frm.set_query("observation_template", "lab_test_prescription", function () {
+		return {
+			filters: {
+				is_billable: 1,
+			},
+		};
 	});
 };
 


### PR DESCRIPTION
Issue description: 
In Patient Encounter  Lab Tests child table allows selecting any Observation Template in the observation_template field. Because this field is not filtered by is_billable, child observation components such as Haemoglobin can be selected directly instead of the parent billable template (for example, CBC). This creates confusion and can lead to incorrect investigation ordering.

Fix applied: Added a shared Patient Encounter query helper so both lab_test_code and observation_template in the lab_test_prescription table only show records where is_billable = 1.

<img width="973" height="303" alt="image" src="https://github.com/user-attachments/assets/3d31d093-11e7-4932-86aa-8a7cbfe47541" />
