### PR TITLE
Feat: Support no-slot appointments for visiting doctors using Practitioner Availability

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -936,8 +936,8 @@ def build_availability_data(availability, appointment_type, date, practitioner_d
 
 		while current + datetime.timedelta(minutes=appointment_duration) <= end:
 			slot_start = current.time().strftime("%H:%M:%S")
-			slot_end = (current + datetime.timedelta(minutes=appointment_duration)).time().strftime(
-				"%H:%M:%S"
+			slot_end = (
+				(current + datetime.timedelta(minutes=appointment_duration)).time().strftime("%H:%M:%S")
 			)
 			available_slots.append({"from_time": slot_start, "to_time": slot_end})
 			current += datetime.timedelta(minutes=appointment_duration)

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -930,14 +930,26 @@ def build_availability_data(availability, appointment_type, date, practitioner_d
 	start_time = (datetime.datetime.combine(date, datetime.time()) + availability_doc.start_time).time()
 	end_time = (datetime.datetime.combine(date, datetime.time()) + availability_doc.end_time).time()
 
-	current = datetime.datetime.combine(date, start_time)
-	end = datetime.datetime.combine(date, end_time)
+	if availability_doc.create_slots:
+		current = datetime.datetime.combine(date, start_time)
+		end = datetime.datetime.combine(date, end_time)
 
-	while current + datetime.timedelta(minutes=appointment_duration) <= end:
-		slot_start = current.time().strftime("%H:%M:%S")
-		slot_end = (current + datetime.timedelta(minutes=appointment_duration)).time().strftime("%H:%M:%S")
-		available_slots.append({"from_time": slot_start, "to_time": slot_end})
-		current += datetime.timedelta(minutes=appointment_duration)
+		while current + datetime.timedelta(minutes=appointment_duration) <= end:
+			slot_start = current.time().strftime("%H:%M:%S")
+			slot_end = (current + datetime.timedelta(minutes=appointment_duration)).time().strftime(
+				"%H:%M:%S"
+			)
+			available_slots.append({"from_time": slot_start, "to_time": slot_end})
+			current += datetime.timedelta(minutes=appointment_duration)
+	else:
+		available_slots.append(
+			{
+				"from_time": start_time.strftime("%H:%M:%S"),
+				"to_time": end_time.strftime("%H:%M:%S"),
+				"duration": appointment_duration,
+				"maximum_appointments": availability_doc.maximum_appointments,
+			}
+		)
 
 	filters = {
 		"practitioner": practitioner_doc.name,

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -969,6 +969,16 @@ def build_availability_data(availability, appointment_type, date, practitioner_d
 	)
 	appointments.extend(practitioner_availability)
 
+	if not availability_doc.create_slots:
+		window_start = get_time(start_time)
+		window_end = get_time(end_time)
+		appointments = [
+			appointment
+			for appointment in appointments
+			if appointment.get("appointment_time")
+			and window_start <= get_time(appointment.get("appointment_time")) < window_end
+		]
+
 	return (
 		{
 			"slot_name": "Practitioner Availability",

--- a/healthcare/healthcare/doctype/patient_appointment/test_patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/test_patient_appointment.py
@@ -838,7 +838,15 @@ class TestPatientAppointment(HealthcareTestSuite):
 
 
 def create_practitioner_availability(
-	start, end, scope=None, scope_type=None, date=None, type="Available", service_unit=None
+	start,
+	end,
+	scope=None,
+	scope_type=None,
+	date=None,
+	type="Available",
+	service_unit=None,
+	create_slots=1,
+	maximum_appointments=None,
 ):
 	return frappe.get_doc(
 		{
@@ -852,6 +860,8 @@ def create_practitioner_availability(
 			"scope": scope or "Service Unit-A",
 			"status": "Active",
 			"service_unit": service_unit,
+			"create_slots": create_slots,
+			"maximum_appointments": maximum_appointments,
 		}
 	).insert(ignore_permissions=True, ignore_links=True, ignore_if_duplicate=True)
 

--- a/healthcare/healthcare/doctype/patient_appointment/test_patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/test_patient_appointment.py
@@ -847,7 +847,13 @@ def create_practitioner_availability(
 	service_unit=None,
 	create_slots=1,
 	maximum_appointments=None,
+	**kwargs,
 ):
+	if "type" in kwargs:
+		availability_type = kwargs.pop("type")
+	if kwargs:
+		raise TypeError(f"Unexpected keyword arguments: {', '.join(kwargs)}")
+
 	return frappe.get_doc(
 		{
 			"doctype": "Practitioner Availability",

--- a/healthcare/healthcare/doctype/patient_appointment/test_patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/test_patient_appointment.py
@@ -843,7 +843,7 @@ def create_practitioner_availability(
 	scope=None,
 	scope_type=None,
 	date=None,
-	type="Available",
+	availability_type="Available",
 	service_unit=None,
 	create_slots=1,
 	maximum_appointments=None,
@@ -851,7 +851,7 @@ def create_practitioner_availability(
 	return frappe.get_doc(
 		{
 			"doctype": "Practitioner Availability",
-			"type": type,
+			"type": availability_type,
 			"start_date": date or nowdate(),
 			"start_time": start,
 			"end_date": date or nowdate(),

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.js
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.js
@@ -2,6 +2,10 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Practitioner Availability", {
+	refresh: function (frm) {
+		frm.events.toggle_capacity_fields(frm);
+	},
+
 	end_time: function (frm) {
 		frm.events.set_duration(frm);
 	},
@@ -28,11 +32,25 @@ frappe.ui.form.on("Practitioner Availability", {
 	},
 
 	type: function (frm) {
+		frm.events.toggle_capacity_fields(frm);
 		if (
 			frm.doc.type == "Available" &&
 			frm.doc.scope_type != "Healthcare Practitioner"
 		) {
 			frm.set_value("scope_type", "Healthcare Practitioner");
+		}
+	},
+
+	create_slots: function (frm) {
+		frm.events.toggle_capacity_fields(frm);
+	},
+
+	toggle_capacity_fields: function (frm) {
+		const show_capacity =
+			frm.doc.type == "Available" && !cint(frm.doc.create_slots);
+		frm.toggle_reqd("maximum_appointments", show_capacity);
+		if (!show_capacity) {
+			frm.set_value("maximum_appointments", null);
 		}
 	},
 });

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.js
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.js
@@ -49,11 +49,7 @@ frappe.ui.form.on("Practitioner Availability", {
 		const show_capacity =
 			frm.doc.type == "Available" && !cint(frm.doc.create_slots);
 		frm.toggle_reqd("maximum_appointments", show_capacity);
-		if (
-			clear_value &&
-			!show_capacity &&
-			frm.doc.maximum_appointments != null
-		) {
+		if (clear_value && !show_capacity && frm.doc.maximum_appointments != null) {
 			frm.set_value("maximum_appointments", null);
 		}
 	},

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.js
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.js
@@ -32,7 +32,7 @@ frappe.ui.form.on("Practitioner Availability", {
 	},
 
 	type: function (frm) {
-		frm.events.toggle_capacity_fields(frm);
+		frm.events.toggle_capacity_fields(frm, true);
 		if (
 			frm.doc.type == "Available" &&
 			frm.doc.scope_type != "Healthcare Practitioner"
@@ -42,14 +42,18 @@ frappe.ui.form.on("Practitioner Availability", {
 	},
 
 	create_slots: function (frm) {
-		frm.events.toggle_capacity_fields(frm);
+		frm.events.toggle_capacity_fields(frm, true);
 	},
 
-	toggle_capacity_fields: function (frm) {
+	toggle_capacity_fields: function (frm, clear_value = false) {
 		const show_capacity =
 			frm.doc.type == "Available" && !cint(frm.doc.create_slots);
 		frm.toggle_reqd("maximum_appointments", show_capacity);
-		if (!show_capacity) {
+		if (
+			clear_value &&
+			!show_capacity &&
+			frm.doc.maximum_appointments != null
+		) {
 			frm.set_value("maximum_appointments", null);
 		}
 	},

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.json
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.json
@@ -24,6 +24,8 @@
   "end_time",
   "end_date",
   "duration",
+  "create_slots",
+  "maximum_appointments",
   "column_break_cena",
   "repeat",
   "monday",
@@ -139,6 +141,21 @@
    "precision": "0",
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "default": "1",
+   "depends_on": "eval:doc.type == \"Available\"",
+   "fieldname": "create_slots",
+   "fieldtype": "Check",
+   "label": "Create Slots"
+  },
+  {
+   "depends_on": "eval:doc.type == \"Available\" && !doc.create_slots",
+   "fieldname": "maximum_appointments",
+   "fieldtype": "Int",
+   "label": "Maximum Number of Appointments (Nos)",
+   "mandatory_depends_on": "eval:doc.type == \"Available\" && !doc.create_slots",
+   "non_negative": 1
   },
   {
    "fieldname": "column_break_gsyx",

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.py
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.py
@@ -9,6 +9,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import DocType
 from frappe.utils import (
+	cint,
 	add_to_date,
 	date_diff,
 	get_datetime,
@@ -48,6 +49,7 @@ class PractitionerAvailability(Document):
 			return
 
 		self.create_slots = 1 if self.create_slots is None else self.create_slots
+		self.create_slots = cint(self.create_slots)
 
 		if not self.create_slots:
 			if not self.maximum_appointments or self.maximum_appointments <= 0:

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.py
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.py
@@ -9,8 +9,8 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import DocType
 from frappe.utils import (
-	cint,
 	add_to_date,
+	cint,
 	date_diff,
 	get_datetime,
 	get_link_to_form,
@@ -54,9 +54,7 @@ class PractitionerAvailability(Document):
 		if not self.create_slots:
 			if not self.maximum_appointments or self.maximum_appointments <= 0:
 				frappe.throw(
-					_(
-						"Maximum Number of Appointments (Nos) is mandatory when Create Slots is unchecked."
-					)
+					_("Maximum Number of Appointments (Nos) is mandatory when Create Slots is unchecked.")
 				)
 		else:
 			self.maximum_appointments = None

--- a/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.py
+++ b/healthcare/healthcare/doctype/practitioner_availability/practitioner_availability.py
@@ -22,6 +22,7 @@ from frappe.utils import (
 class PractitionerAvailability(Document):
 	def validate(self):
 		self.set_fallbacks()
+		self.validate_capacity_settings()
 		self.set_title()
 		self.validate_start_and_end()
 		self.validate_availability_overlaps()
@@ -39,6 +40,24 @@ class PractitionerAvailability(Document):
 			start = datetime.combine(getdate(self.start_date), get_time(self.start_time))
 			end = datetime.combine(getdate(self.end_date), get_time(self.end_time))
 			self.duration = int(time_diff_in_seconds(end, start) / 60)
+
+	def validate_capacity_settings(self):
+		if self.type != "Available":
+			self.create_slots = 1
+			self.maximum_appointments = None
+			return
+
+		self.create_slots = 1 if self.create_slots is None else self.create_slots
+
+		if not self.create_slots:
+			if not self.maximum_appointments or self.maximum_appointments <= 0:
+				frappe.throw(
+					_(
+						"Maximum Number of Appointments (Nos) is mandatory when Create Slots is unchecked."
+					)
+				)
+		else:
+			self.maximum_appointments = None
 
 	def validate_start_and_end(self):
 		if not self.start_time or not self.end_time:

--- a/healthcare/healthcare/doctype/practitioner_availability/test_practitioner_availability.py
+++ b/healthcare/healthcare/doctype/practitioner_availability/test_practitioner_availability.py
@@ -36,6 +36,8 @@ class IntegrationTestPractitionerAvailability(HealthcareTestSuite):
 		end_date=None,
 		type="Available",
 		service_unit=None,
+		create_slots=1,
+		maximum_appointments=None,
 	):
 		return frappe.get_doc(
 			{
@@ -49,6 +51,8 @@ class IntegrationTestPractitionerAvailability(HealthcareTestSuite):
 				"scope": scope or "Service Unit-A",
 				"status": "Active",
 				"service_unit": service_unit,
+				"create_slots": create_slots,
+				"maximum_appointments": maximum_appointments,
 			}
 		).insert(ignore_permissions=True, ignore_links=True, ignore_if_duplicate=True)
 
@@ -61,6 +65,17 @@ class IntegrationTestPractitionerAvailability(HealthcareTestSuite):
 			service_unit="Service Unit-A",
 		)
 		self.assertEqual(pa.duration, 30)
+
+	def test_maximum_appointments_required_when_create_slots_unchecked(self):
+		with self.assertRaises(frappe.ValidationError):
+			self.create_practitioner_availability(
+				"08:00:00",
+				"09:00:00",
+				scope_type="Healthcare Practitioner",
+				scope=self.practitioner,
+				service_unit="Service Unit-A",
+				create_slots=0,
+			)
 
 	def test_simple_overlap(self):
 		self.create_practitioner_availability(


### PR DESCRIPTION
Issue
For visiting doctors, we normally uses Practitioner Availability instead of Practitioner Schedule. However, Practitioner Availability only supported slot-based appointment behavior, and no-slot appointment booking was not available there.
Because of this:
  - visiting doctors could not be configured like schedule-based no-slot appointments
  - users could not define a maximum number of appointments for an availability block
  - practitioner availability did not behave consistently with practitioner schedule


Fix:-
This change updates Practitioner Availability so that when Type = Available, users can choose whether to create slots or allow no-slot appointments with a maximum appointment limit.
  - Added a Create Slots checkbox to Practitioner Availability
  - Made Create Slots visible only when Type = Available
  - Added Maximum Number of Appointments (Nos) when Create Slots is unchecked
  - Made Maximum Number of Appointments (Nos) mandatory in no-slot mode
  - Reused schedule-like behavior so availability can support capacity-based booking for visiting doctors
  - 
without slot:-
<img width="1004" height="501" alt="image" src="https://github.com/user-attachments/assets/942625d5-f1f8-41ca-ab1f-a0a3b06e8093" />

with slot:-

<img width="826" height="439" alt="image" src="https://github.com/user-attachments/assets/5d092125-e0cf-4237-ad73-5001d7110cf5" />

no-docs

