### PR TITLE
fix(healthcare): prevent false "Not Saved" state in Diagnostic Report after Frappe update

### DIFF
--- a/healthcare/public/js/observation_widget.js
+++ b/healthcare/public/js/observation_widget.js
@@ -161,6 +161,8 @@ healthcare.ObservationWidget = class {
 
 	init_field_group(obs_data, wrapper) {
 		var me = this;
+		me._is_rendering_result_field = me._is_rendering_result_field || {};
+		me._is_rendering_result_field[obs_data.name] = true;
 		var default_input = "";
 		if (
 			["Range", "Ratio", "Quantity", "Numeric"].includes(
@@ -206,7 +208,10 @@ healthcare.ObservationWidget = class {
 					fieldtype: fieldtype,
 					options: options,
 					read_only: 1 ? obs_data.status == "Approved" : 0,
-					change: s => {
+					change: () => {
+						if (me._is_rendering_result_field[obs_data.name]) {
+							return;
+						}
 						me.frm.dirty();
 						me.set_result_n_name(obs_data.name);
 					},
@@ -286,6 +291,9 @@ healthcare.ObservationWidget = class {
 		});
 		me[obs_data.name].make();
 		me.set_values(this, obs_data);
+		setTimeout(() => {
+			me._is_rendering_result_field[obs_data.name] = false;
+		}, 0);
 	}
 
 	set_values(th, obs_data) {


### PR DESCRIPTION
Issue:-
After upgrading to the latest Frappe/ERPNext version, opening an already approved Diagnostic Report was showing the form in an unsaved state even though no user changes had been made.

Testing
1. Opening an approved Diagnostic Report after the Frappe/ERPNext update
2. Confirming the form no longer shows a false "Not Saved" indicator on load
3. Verifying that actual user edits still mark the form as unsaved

<img width="1128" height="313" alt="image" src="https://github.com/user-attachments/assets/cc7adec3-44c0-418e-98be-120006f9cc3c" />


This was causing confusion because:
- the report status was already approved
- no visible data was changed by the user
- the form header still showed "Not Saved"


Root Cause:-
The Diagnostic Report observation widget renders result fields using a custom FieldGroup-based UI.
In newer Frappe versions, field initialization/default hydration during render can trigger the custom result field change handler. That handler was directly calling frm.dirty(), which marked the document as unsaved during initial render instead of only during actual user edits.

As a result, simply loading the Diagnostic Report UI could incorrectly set the form to a dirty state.

Fix
After upgrading to newer Frappe/ERPNext versions, the Observation Widget's result field change event could be triggered during field initialization and value hydration. Since the handler directly called frm.dirty(), approved Diagnostic Reports were incorrectly marked as Not Saved immediately after loading.

This fix adds a render-time guard to ignore change events fired during field initialization. As a result:

  - Initial observation value hydration no longer marks the form as unsaved.
  - Actual user modifications continue to mark the form dirty as expected.
  - The behavior remains consistent and compatible across newer Frappe version

Files Changed
- healthcare/public/js/observation_widget.js

Notes
After pulling this change, run:
bench build --app healthcare