### PR TITLE
fix(inpatient-record): restore inpatient billable generation on version-16

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -212,6 +212,7 @@ class InpatientRecord(Document):
 						"customer": frappe.db.get_value("Patient", self.patient, "customer"),
 						"selling_price_list": self.price_list or price_list,
 						"price_list_currency": self.currency or price_list_currency,
+						"currency": self.currency or price_list_currency,
 						"plc_conversion_rate": 1.0,
 						"conversion_rate": 1.0,
 						"qty": 1,
@@ -588,7 +589,7 @@ def admit_patient(
 	inpatient_record.admitted_datetime = check_in
 	inpatient_record.status = "Admitted"
 	inpatient_record.expected_discharge = expected_discharge
-	inpatient_record.currency = currency
+	inpatient_record.currency = currency or inpatient_record.currency
 	inpatient_record.price_list = price_list
 
 	inpatient_record.set("inpatient_occupancies", [])


### PR DESCRIPTION
Issue:-
In version-16, the Generate Billables action in Patient/Inpatient Record was not populating the billable items table under the Inpatient Billables tab, even though the same flow was working in develop.
The UI button and tab were already present, so the problem was in the backend billing flow.

Root cause:-
While comparing develop and version-16, the regression was found in Inpatient Record billable generation:
version-16 was missing the currency key in the ItemDetailsCtx passed to get_item_details() during inpatient billable generation.
version-16 also set inpatient_record.currency = currency during admission, which could overwrite/clear the existing document currency unnecessarily.

Because of this, item detail resolution for generated billables could fail on v16, causing the button to appear non-working and the billables table to remain empty.

<img width="1235" height="318" alt="image" src="https://github.com/user-attachments/assets/d7dfebee-9eea-4654-8b82-42d6ec664b99" />


Fix applied:-
Updated healthcare/healthcare/doctype/inpatient_record/inpatient_record.py to:
  - restore currency in the ItemDetailsCtx used by add_service_unit_rent_to_billable_items()
  - restore safer admission behavior by using:
                inpatient_record.currency = currency or inpatient_record.currency

Result:-
- Generate Billables should now correctly resolve item pricing/details
- billable rows should populate again in the Inpatient Billables tab on version-16
- behavior is aligned back with the working develop branch