### PR TITLE
Fix:- missing "To" field in Observation Reference Range form for Quantity permitted datatype

### DIFF
--- a/healthcare/healthcare/doctype/observation_reference_range/observation_reference_range.json
+++ b/healthcare/healthcare/doctype/observation_reference_range/observation_reference_range.json
@@ -80,7 +80,6 @@
    "label": "Reference Text"
   },
   {
-   "depends_on": "eval:doc.permitted_data_type!=\"Quantity\";",
    "fieldname": "column_break_l8sr",
    "fieldtype": "Column Break"
   },


### PR DESCRIPTION
Issue description:
In Observation Template, when Permitted Data Type is set to Quantity, the To field in the Observation Reference Range child row is not shown in the form editor when clickedon pencil icon. The same field can still be added in the grid or table using Add Columns manually by the user, so the field exists but the form view does not render it.

<img width="951" height="828" alt="image" src="https://github.com/user-attachments/assets/f99b5c25-2ed9-4588-8ec9-767737257d24" />

This causes inconsistent behavior between:
  - child table grid view
  - child row form view

Root cause:
The child DocType Observation Reference Range had a depends_on condition on the layout field column_break_l8sr:
                            eval:doc.permitted_data_type!="Quantity"

Since the reference_to field is placed after that column break, hiding the column break for Quantity also prevented the To field from appearing properly in the row form editor.

Fix applied:
Removed the depends_on condition from column_break_l8sr in observation_reference_range.json

Result:
  - To is now visible in the Observation Reference Range form view for Quantity
  - grid view and form view now behave consistently
  - this is a metadata/layout fix only; 
  
<img width="969" height="798" alt="image" src="https://github.com/user-attachments/assets/98d3dd13-139a-4fe9-a8ab-5210118e690e" />

Note:
Run bench --site <site-name> migrate to apply the DocType metadata change and reflect it in the UI.

Closes #959 issue.
 Also required for version-16 branch 

