### PR TITLE
fix(patient-appointment): missing Patient Encounter series when created from Patient Appointment

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -237,10 +237,7 @@ frappe.ui.form.on("Patient Appointment", {
 				frm.add_custom_button(
 					__("Patient Encounter"),
 					function () {
-						frappe.model.open_mapped_doc({
-							method: "healthcare.healthcare.doctype.patient_appointment.patient_appointment.make_encounter",
-							frm: frm,
-						});
+						create_patient_encounter(frm);
 					},
 					__("Create"),
 				);
@@ -1246,6 +1243,29 @@ let reschedule_dept_or_su = function (frm) {
 	d.set_value("appointment_date", frm.doc.appointment_date);
 	d.set_value(field_config.fieldname, frm.doc[field_config.fieldname]);
 	d.show();
+};
+
+let create_patient_encounter = function (frm) {
+	if (!frm.doc.patient) {
+		frappe.throw(__("Please select patient"));
+	}
+
+	frappe.route_options = {
+		appointment: frm.doc.name,
+		patient: frm.doc.patient,
+		practitioner: frm.doc.practitioner,
+		medical_department: frm.doc.department,
+		patient_sex: frm.doc.patient_sex,
+		invoiced: frm.doc.invoiced,
+		company: frm.doc.company,
+		appointment_type: frm.doc.appointment_type,
+		insurance_policy: frm.doc.insurance_policy,
+		insurance_coverage: frm.doc.insurance_coverage,
+		inpatient_record: frm.doc.inpatient_record,
+		encounter_date: frm.doc.appointment_date,
+		encounter_time: frm.doc.appointment_time,
+	};
+	frappe.new_doc("Patient Encounter");
 };
 
 let create_vital_signs = function (frm) {


### PR DESCRIPTION
Issue:
When Patient Encounter was created from the Create Patient Encounter button on Patient Appointment, the form opened through open_mapped_doc. That path mapped field values from the appointment, but it skipped the normal new_doc default initialization, so naming_series stayed blank. A blank series can cause incorrect naming/sequence behavior when the encounter is saved. The normal or independent patient encounter were properly setting series field correctly, issue is with encounter created from appointment.

Before fix:
<img width="748" height="369" alt="image" src="https://github.com/user-attachments/assets/96922816-3b89-44db-8ef9-ad628137bc16" />


Fix:
Changed the Patient Encounter create action in Patient Appointment set frappe.route_options with the appointment-derived values and open the form with frappe.new_doc("Patient Encounter"). This keeps the encounter fields prefilled and allows Frappe to apply the default naming_series correctly.

After fix:
<img width="771" height="478" alt="image" src="https://github.com/user-attachments/assets/bc47e610-6ac4-4318-973f-65922319147f" />

Note:-
Also required for version-16 branch, the above issue also exists there.