### PR TITLE
fix(Sample Collection): fetch reference_doc when linking sales invoice to observation

### DIFF
--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -91,7 +91,7 @@ def insert_observation(selected, sample_collection, component_observations=None,
 		sample_col_doc = frappe.db.get_value(
 			"Sample Collection",
 			sample_collection,
-			["reference_name", "patient", "referring_practitioner"],
+			["reference_name", "reference_doc", "patient", "referring_practitioner"],
 			as_dict=1,
 		)
 		selected = json.loads(selected)


### PR DESCRIPTION
## Summary
Fixes #1061

PR #555 added a conditional check so `sales_invoice` is only set when the Sample Collection comes from a Sales Invoice. However, `insert_observation()` never fetches `reference_doc` from the database, so the condition is always false and `sales_invoice` stays NULL after Mark Collected. This resulted in Diagnostic report not having "Result entry" UI for the observations within it.

## Fix
Add `reference_doc` to the `frappe.db.get_value()` field list in `insert_observation()`.

## Test plan
- [ ] Create Sales Invoice with a lab test that requires sample collection
- [ ] Submit invoice → Sample Collection created with `reference_doc = Sales Invoice`
- [ ] Mark Collected
- [ ] Confirm Observation has `sales_invoice` set to the invoice name
- [ ] Open Diagnostic Report → result entry widgets load
- [ ] Confirm encounter-based sample collections still get `sales_invoice = NULL` (no invalid invoice reference)