### PR TITLE
fix(encounter):  Patient Encounter series when created from Patient Appointment

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -1071,7 +1071,7 @@ def send_confirmation_msg(doc):
 
 
 @frappe.whitelist()
-def make_encounter(source_name, target_doc=None):
+def make_encounter(source_name: str, target_doc: Document | None = None) -> Document:
 	doc = get_mapped_doc(
 		"Patient Appointment",
 		source_name,

--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -1078,6 +1078,7 @@ def make_encounter(source_name, target_doc=None):
 		{
 			"Patient Appointment": {
 				"doctype": "Patient Encounter",
+				"field_no_map": ["naming_series"],
 				"field_map": [
 					["appointment", "name"],
 					["patient", "patient"],


### PR DESCRIPTION
Issue description: 
Creating a Patient Encounter from the Create button on Patient Appointment was incorrectly carrying over the appointment’s naming_series through get_mapped_doc() in make_encounter(). Because of that, encounters created from appointments could use the wrong series and produce an incorrect sequence. Directly created Patient Encounter records did not have this problem because they used the encounter doctype’s own naming logic.

Fix applied:
 Added field_no_map: ["naming_series"] to the server-side get_mapped_doc() mapping in patient_appointment.py. This prevents naming_series from being copied from Patient Appointment to Patient Encounter, allowing the encounter to resolve its own configured series. 