### PR TITLE
feat(healthcare): add inpatient record to diagnostic report for OP/IP differentiation

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -17,6 +17,7 @@
   "column_break_v6l1",
   "company",
   "status",
+  "inpatient_record",
   "naming_series",
   "ref_doctype",
   "docname",
@@ -145,6 +146,15 @@
    "in_standard_filter": 1,
    "label": "Company",
    "options": "Company",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "sample_collection.inpatient_record",
+   "fieldname": "inpatient_record",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Inpatient Record",
+   "options": "Inpatient Record",
    "read_only": 1
   },
   {

--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -149,8 +149,6 @@
    "read_only": 1
   },
   {
-   "fetch_from": "sample_collection.inpatient_record",
-   "fetch_if_empty": 1,
    "fieldname": "inpatient_record",
    "fieldtype": "Link",
    "in_standard_filter": 1,

--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -150,6 +150,7 @@
   },
   {
    "fetch_from": "sample_collection.inpatient_record",
+   "fetch_if_empty": 1,
    "fieldname": "inpatient_record",
    "fieldtype": "Link",
    "in_standard_filter": 1,

--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
@@ -11,6 +11,7 @@ from healthcare.healthcare.doctype.observation.observation import get_observatio
 class DiagnosticReport(Document):
 	def validate(self):
 		self.set_reference_details()
+		self.set_inpatient_record()
 		self.set_age()
 		self.set_title()
 		# set_diagnostic_status(self)
@@ -24,6 +25,14 @@ class DiagnosticReport(Document):
 			patient_doc = frappe.get_doc("Patient", self.patient)
 			if patient_doc.dob:
 				self.age = patient_doc.calculate_age(self.reference_posting_date).get("age_in_string")
+
+	def set_inpatient_record(self):
+		if self.sample_collection:
+			self.inpatient_record = frappe.db.get_value(
+				"Sample Collection", self.sample_collection, "inpatient_record"
+			)
+		elif not self.inpatient_record and self.patient:
+			self.inpatient_record = frappe.db.get_value("Patient", self.patient, "inpatient_record")
 
 	def set_title(self):
 		self.title = f"{self.patient_name} - {self.age or ''} {self.gender}"

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -353,7 +353,12 @@ def make_observation(service_request, appointment=None):
 			"Diagnostic Report", diagnostic_report, "sample_collection"
 		):
 			frappe.db.set_value(
-				"Diagnostic Report", diagnostic_report, "sample_collection", sample_collection.name
+				"Diagnostic Report",
+				diagnostic_report,
+				{
+					"sample_collection": sample_collection.name,
+					"inpatient_record": sample_collection.inpatient_record,
+				},
 			)
 		return sample_collection.name, "Sample Collection"
 	elif observation:
@@ -409,6 +414,12 @@ def insert_diagnostic_report(doc, sample_collection=None):
 	diagnostic_report.docname = doc.order_group
 	diagnostic_report.practitioner = doc.practitioner
 	diagnostic_report.sample_collection = sample_collection
+	if sample_collection:
+		diagnostic_report.inpatient_record = frappe.db.get_value(
+			"Sample Collection", sample_collection, "inpatient_record"
+		)
+	else:
+		diagnostic_report.inpatient_record = doc.inpatient_record
 	diagnostic_report.save(ignore_permissions=True)
 
 

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -231,7 +231,7 @@ def make_lab_test(service_request):
 
 
 @frappe.whitelist()
-def make_observation(service_request, appointment=None):
+def make_observation(service_request: str, appointment: str | None = None):
 	if not service_request:
 		return
 


### PR DESCRIPTION
Issue:
Diagnostic Report did not have an inpatient_record field, so OP/IP differentiation was not available at the report level.
This affected both cases:
- Laboratory workflows, where the inpatient context exists on Sample Collection but was not stored on Diagnostic Report
- Imaging/direct observation workflows, where no Sample Collection may exist, so the report had no field to carry inpatient context

Because of that, Diagnostic Reports could not be reliably identified as OP or IP.

Fix applied:

- Added inpatient_record field to Diagnostic Report
- For laboratory/sample-based flows, populated Diagnostic Report.inpatient_record from linked Sample Collection.inpatient_record
- For direct observation/imaging flows without sample collection, populated Diagnostic Report.inpatient_record from doc.inpatient_record during report creation
- Added server-side fallback in Diagnostic Report validation to populate inpatient_record from Patient.inpatient_record if it is still empty
- Updated the Diagnostic Report update logic so when a sample collection is linked later, both sample_collection and inpatient_record are updated on the report
- Removed DocField-level auto-fetch for inpatient_record so the value is controlled only by server-side logic

Result:
Diagnostic Report now stores inpatient context for both:

- laboratory cases using sample collection
- imaging/direct observation cases without sample collection

This enables reliable OP/IP differentiation directly from the Diagnostic Report.

Test cases:

- Create a laboratory/sample-based Service Request (from encounter)  for an IP patient and verify the generated Diagnostic Report gets inpatient_record from the linked Sample Collection

- Create an imaging/direct observation Service Reques (from encounter) for an IP patient and verify the generated Diagnostic Report gets inpatient_record from doc.inpatient_record



<img width="1044" height="773" alt="xray" src="https://github.com/user-attachments/assets/be00abed-2b0e-43e3-8027-395b3a7daeb4" />

<img width="1014" height="656" alt="CBC" src="https://github.com/user-attachments/assets/70ab6928-8095-4b5c-b386-8634cda15a66" />


no-docs

