### PR TITLE
fix: add inpatient_record in diagnostic report

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -10,6 +10,7 @@
  "field_order": [
   "patient",
   "patient_name",
+  "inpatient_record",
   "gender",
   "age",
   "practitioner",
@@ -44,6 +45,14 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Patient Name",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "patient.inpatient_record",
+   "fieldname": "inpatient_record",
+   "fieldtype": "Link",
+   "label": "Inpatient Record",
+   "options": "Inpatient Record",
    "read_only": 1
   },
   {


### PR DESCRIPTION
Issue:
Diagnostic Report did not have an inpatient_record field, which made it difficult to distinguish inpatient and outpatient diagnostic reports. This impacted both laboratory and imaging-related report handling where OP/IP context is needed.

This change adds a readonly inpatient_record field to Diagnostic Report and fetches its value from the linked Patient record using fetch_from: "patient.inpatient_record".

With this update:
Diagnostic Reports can carry the patient’s inpatient reference directly
OP and IP reports can be differentiated more easily
The change stays minimal and limited to the DocType JSON definition only

Fix applied:
Added inpatient_record to the Diagnostic Report field list and field order in diagnostic_report.json

Test Cases:-
Create Encounter for both laboratory and imaging observation templates and check whether the generated report has inpatient record.
no-docs