### PR TITLE
fix: retain inpatient record on diagnostic reports after patient discharge

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -53,7 +53,8 @@
    "fieldtype": "Link",
    "label": "Inpatient Record",
    "options": "Inpatient Record",
-   "read_only": 1
+   "read_only": 1,
+   "fetch_if_empty": 1
   },
   {
    "fieldname": "column_break_v6l1",


### PR DESCRIPTION
When a Diagnostic Report is created for an admitted patient, the inpatient_record is fetched from the Patient master. If payment is completed and the patient is discharged before the report is saved or finalized, the Patient document no longer holds that active inpatient_record. As a result, the field can become blank on the Diagnostic Report, which breaks traceability back to the admission tied to the report.

Fix applied:-
Added fetch_if_empty: 1 to the inpatient_record field on the Diagnostic Report doctype. This keeps the already-fetched value on the report and prevents it from being overwritten with an empty value when patient.inpatient_record is cleared after discharge.