### PR TITLE
fix(inpatient-medication-order): skip duplicate inpatient medication order check when patient encounter is blank

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
@@ -31,6 +31,9 @@ class InpatientMedicationOrder(Document):
 			frappe.throw(_("No Inpatient Record found against patient {0}").format(self.patient))
 
 	def validate_duplicate(self):
+		if not self.patient_encounter:
+			return
+
 		existing_mo = frappe.db.exists(
 			"Inpatient Medication Order",
 			{
@@ -87,3 +90,4 @@ class InpatientMedicationOrder(Document):
 			return
 		for drug in patient_encounter.drug_prescription:
 			self.add_order_entries(drug)
+

--- a/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
@@ -90,4 +90,3 @@ class InpatientMedicationOrder(Document):
 			return
 		for drug in patient_encounter.drug_prescription:
 			self.add_order_entries(drug)
-

--- a/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
@@ -94,7 +94,12 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 		second_ipmo.insert()
 
 		self.assertTrue(first_ipmo.name)
+		self.assertEqual(first_ipmo.docstatus, 0)
+		self.assertFalse(first_ipmo.patient_encounter)
+
 		self.assertTrue(second_ipmo.name)
+		self.assertEqual(second_ipmo.docstatus, 0)
+		self.assertFalse(second_ipmo.patient_encounter)
 
 	def tearDown(self):
 		if frappe.db.get_value("Patient", self.patient, "inpatient_record"):

--- a/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
@@ -85,6 +85,17 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 		ipmo.reload()
 		self.assertEqual(ipmo.status, "Completed")
 
+	def test_multiple_orders_without_patient_encounter(self):
+		first_ipmo = create_ipmo(self.patient)
+		first_ipmo.insert()
+
+		second_ipmo = create_ipmo(self.patient)
+		second_ipmo.start_date = add_days(getdate(), 2)
+		second_ipmo.insert()
+
+		self.assertTrue(first_ipmo.name)
+		self.assertTrue(second_ipmo.name)
+
 	def tearDown(self):
 		if frappe.db.get_value("Patient", self.patient, "inpatient_record"):
 			# cleanup - Discharge
@@ -158,3 +169,5 @@ def create_ipme(filters, update_stock=0):
 	ipme = ipme.get_medication_orders()
 
 	return ipme
+
+

--- a/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
@@ -169,5 +169,3 @@ def create_ipme(filters, update_stock=0):
 	ipme = ipme.get_medication_orders()
 
 	return ipme
-
-


### PR DESCRIPTION
Issue Description:-
When creating an Inpatient Medication Order for an admitted patient without linking a Patient Encounter, the first order is saved successfully. However, any subsequent inpatient medication order without a linked encounter fails with a DuplicateEntryError.

Error shown:
                      An Inpatient Medication Order HLC-IMO-2026-00001 against Patient Encounter None already exists.

Root cause:
The duplicate validation checks only patient_encounter. When the field is empty, all records with patient_encounter = None are treated as duplicates of each other.

Fix Applied:-
Updated duplicate validation in Inpatient Medication Order to skip the duplicate check when patient_encounter is not set.

This ensures:
orders linked to a Patient Encounter still preserve the existing duplicate protection
orders created without a linked encounter are no longer incorrectly blocked as duplicates

