### PR TITLE
feat: support separate diagnostic reports per observation category if the setting is enabled

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -24,6 +24,7 @@
   "sales_invoice_status",
   "reference_posting_date",
   "sample_collection",
+  "observation_category",
   "section_break_wtn1",
   "observation",
   "amended_from",
@@ -109,6 +110,15 @@
    "label": "Sample Collection",
    "options": "Sample Collection",
    "search_index": 1
+  },
+  {
+   "fieldname": "observation_category",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "in_standard_filter": 1,
+   "label": "Observation Category",
+   "options": "\nSocial History\nVital Signs\nImaging\nLaboratory\nProcedure\nSurvey\nExam\nTherapy\nActivity",
+   "read_only": 1
   },
   {
    "fieldname": "amended_from",

--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
@@ -26,7 +26,8 @@ class DiagnosticReport(Document):
 				self.age = patient_doc.calculate_age(self.reference_posting_date).get("age_in_string")
 
 	def set_title(self):
-		self.title = f"{self.patient_name} - {self.age or ''} {self.gender}"
+		category = f" - {self.observation_category}" if self.observation_category else ""
+		self.title = f"{self.patient_name} - {self.age or ''} {self.gender}{category}"
 
 	def set_reference_details(self):
 		if self.ref_doctype == "Sales Invoice" and self.docname:
@@ -43,15 +44,19 @@ def diagnostic_report_print(diagnostic_report):
 
 def validate_observations_has_result(doc):
 	if doc.ref_doctype == "Sales Invoice":
+		filters = {
+			"sales_invoice": doc.docname,
+			"docstatus": ["!=", 2],
+			"has_component": False,
+			"status": ["!=", "Cancelled"],
+		}
+		if doc.observation_category:
+			filters["observation_category"] = doc.observation_category
+
 		submittable = True
 		observations = frappe.db.get_all(
 			"Observation",
-			{
-				"sales_invoice": doc.docname,
-				"docstatus": ["!=", 2],
-				"has_component": False,
-				"status": ["!=", "Cancelled"],
-			},
+			filters,
 			pluck="name",
 		)
 		for obs in observations:
@@ -63,9 +68,12 @@ def validate_observations_has_result(doc):
 def set_diagnostic_status(doc):
 	if doc.get("__islocal"):
 		return
+	filters = {"sales_invoice": doc.docname, "docstatus": 0, "status": ["!=", "Approved"], "has_component": 0}
+	if doc.observation_category:
+		filters["observation_category"] = doc.observation_category
 	observations = frappe.db.get_all(
 		"Observation",
-		{"sales_invoice": doc.docname, "docstatus": 0, "status": ["!=", "Approved"], "has_component": 0},
+		filters,
 	)
 	workflow_name = get_workflow_name("Diagnostic Report")
 	workflow_state_field = get_workflow_state_field(workflow_name)
@@ -81,14 +89,18 @@ def set_diagnostic_status(doc):
 def set_observation_status(docname):
 	doc = frappe.get_doc("Diagnostic Report", docname)
 	if doc.ref_doctype == "Sales Invoice":
+		filters = {
+			"sales_invoice": doc.docname,
+			"docstatus": ["!=", 2],
+			"has_component": False,
+			"status": ["not in", ["Cancelled", "Approved", "Rejected"]],
+		}
+		if doc.observation_category:
+			filters["observation_category"] = doc.observation_category
+
 		observations = frappe.db.get_all(
 			"Observation",
-			{
-				"sales_invoice": doc.docname,
-				"docstatus": ["!=", 2],
-				"has_component": False,
-				"status": ["not in", ["Cancelled", "Approved", "Rejected"]],
-			},
+			filters,
 			pluck="name",
 		)
 		if observations:

--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.py
@@ -86,7 +86,7 @@ def set_diagnostic_status(doc):
 
 
 @frappe.whitelist()
-def set_observation_status(docname):
+def set_observation_status(docname: str):
 	doc = frappe.get_doc("Diagnostic Report", docname)
 	if doc.ref_doctype == "Sales Invoice":
 		filters = {

--- a/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
+++ b/healthcare/healthcare/doctype/healthcare_settings/healthcare_settings.json
@@ -34,6 +34,7 @@
   "sb_lab_settings",
   "create_lab_test_on_si_submit",
   "create_observation_on_si_submit",
+  "create_separate_diagnostic_report_based_on_observation_category",
   "create_sample_collection_for_lab_test",
   "column_break_34",
   "lab_test_approval_required",
@@ -236,6 +237,13 @@
   },
   {
    "default": "0",
+   "description": "If enabled, Diagnostic Reports created from Observations will be split into separate reports for each Observation Category. If disabled, the existing single Diagnostic Report behavior is preserved.",
+   "fieldname": "create_separate_diagnostic_report_based_on_observation_category",
+   "fieldtype": "Check",
+   "label": "Create Separate Diagnostic Report Based on Observation Category"
+  },
+  {
+   "default": "0",
    "description": "Checking this will create a Sample Collection document  every time you create a Lab Test",
    "fieldname": "create_sample_collection_for_lab_test",
    "fieldtype": "Check",
@@ -356,7 +364,7 @@
   {
    "fieldname": "laboratory_tab",
    "fieldtype": "Tab Break",
-   "label": "Laboratory"
+   "label": "Diagnostics"
   },
   {
    "fieldname": "billing_accounts",

--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -144,7 +144,7 @@ class Observation(Document):
 
 
 @frappe.whitelist()
-def get_observation_details(docname):
+def get_observation_details(docname: str):
 	reference = frappe.get_value(
 		"Diagnostic Report", docname, ["docname", "ref_doctype", "observation_category"], as_dict=True
 	)

--- a/healthcare/healthcare/doctype/observation/observation.py
+++ b/healthcare/healthcare/doctype/observation/observation.py
@@ -145,19 +145,26 @@ class Observation(Document):
 
 @frappe.whitelist()
 def get_observation_details(docname):
-	reference = frappe.get_value("Diagnostic Report", docname, ["docname", "ref_doctype"], as_dict=True)
+	reference = frappe.get_value(
+		"Diagnostic Report", docname, ["docname", "ref_doctype", "observation_category"], as_dict=True
+	)
 	observation = []
+	observation_category = reference.get("observation_category")
 
 	if reference.get("ref_doctype") == "Sales Invoice":
+		filters = {
+			"sales_invoice": reference.get("docname"),
+			"parent_observation": "",
+			"status": ["!=", "Cancelled"],
+			"docstatus": ["!=", 2],
+		}
+		if observation_category:
+			filters["observation_category"] = observation_category
+
 		observation = frappe.get_list(
 			"Observation",
 			fields=["*"],
-			filters={
-				"sales_invoice": reference.get("docname"),
-				"parent_observation": "",
-				"status": ["!=", "Cancelled"],
-				"docstatus": ["!=", 2],
-			},
+			filters=filters,
 			order_by="creation",
 		)
 	elif reference.get("ref_doctype") == "Patient Encounter":
@@ -172,15 +179,19 @@ def get_observation_details(docname):
 			order_by="creation",
 			pluck="name",
 		)
+		filters = {
+			"service_request": ["in", service_requests],
+			"parent_observation": "",
+			"status": ["!=", "Cancelled"],
+			"docstatus": ["!=", 2],
+		}
+		if observation_category:
+			filters["observation_category"] = observation_category
+
 		observation = frappe.get_list(
 			"Observation",
 			fields=["*"],
-			filters={
-				"service_request": ["in", service_requests],
-				"parent_observation": "",
-				"status": ["!=", "Cancelled"],
-				"docstatus": ["!=", 2],
-			},
+			filters=filters,
 			order_by="creation",
 		)
 
@@ -547,11 +558,15 @@ def set_diagnostic_report_status(doc):
 				"Sample Collection", doc.reference_docname, ["reference_doc", "reference_name"]
 			)
 
-		diagnostic_report = frappe.db.get_value(
-			"Diagnostic Report", {"ref_doctype": ref_doctype, "docname": ref_docname}, "name"
-		)
+		report_filters = {"ref_doctype": ref_doctype, "docname": ref_docname}
+		if doc.observation_category and frappe.db.exists(
+			"Diagnostic Report", {**report_filters, "observation_category": doc.observation_category}
+		):
+			report_filters["observation_category"] = doc.observation_category
 
-		if diagnostic_report:
+		diagnostic_reports = frappe.get_all("Diagnostic Report", filters=report_filters, pluck="name")
+
+		for diagnostic_report in diagnostic_reports:
 			out_data, obs_length = get_observation_details(diagnostic_report)
 			approved_observations = get_approved_observations(out_data)
 

--- a/healthcare/healthcare/doctype/observation/test_observation.py
+++ b/healthcare/healthcare/doctype/observation/test_observation.py
@@ -165,6 +165,29 @@ class TestObservation(HealthcareTestSuite):
 			)
 		)
 
+	def test_separate_diagnostic_reports_from_invoice_by_observation_category(self):
+		self.enable_observation_on_invoice_submit()
+		frappe.db.set_single_value(
+			"Healthcare Settings", "create_separate_diagnostic_report_based_on_observation_category", 1
+		)
+
+		patient = self.get_test_patient()
+		lab_template = frappe.get_doc("Observation Template", "_Test Observation without Sample")
+		imaging_template = create_imaging_observation_template("_Test Observation Imaging")
+		sales_invoice = create_sales_invoice(patient, [lab_template.name, imaging_template.name])
+
+		reports = frappe.get_all(
+			"Diagnostic Report",
+			filters={"docname": sales_invoice.name, "patient": patient},
+			fields=["name", "observation_category"],
+		)
+
+		self.assertEqual(len(reports), 2)
+		self.assertEqual(
+			{report.observation_category for report in reports},
+			{"Laboratory", "Imaging"},
+		)
+
 	def test_observation_from_encounter(self):
 		observation_template = frappe.get_doc("Observation Template", "_Test Observation without Sample")
 		patient = self.get_test_patient()
@@ -384,31 +407,52 @@ class TestObservation(HealthcareTestSuite):
 		create_custom_fields(custom_fields, update=True)
 
 
-def create_sales_invoice(patient, item):
+def create_sales_invoice(patient, items):
 	sales_invoice = frappe.new_doc("Sales Invoice")
 	sales_invoice.patient = patient
 	sales_invoice.customer = frappe.db.get_value("Patient", patient, "customer")
 	sales_invoice.due_date = getdate()
 	sales_invoice.company = "_Test Company"
 	sales_invoice.debit_to = get_receivable_account("_Test Company")
-	sales_invoice.append(
-		"items",
-		{
-			"item_code": item,
-			"item_name": item,
-			"description": item,
-			"qty": 1,
-			"uom": "Nos",
-			"conversion_factor": 1,
-			"income_account": get_income_account(None, "_Test Company"),
-			"rate": 300,
-			"amount": 300,
-		},
-	)
+
+	if isinstance(items, str):
+		items = [items]
+
+	for item in items:
+		sales_invoice.append(
+			"items",
+			{
+				"item_code": item,
+				"item_name": item,
+				"description": item,
+				"qty": 1,
+				"uom": "Nos",
+				"conversion_factor": 1,
+				"income_account": get_income_account(None, "_Test Company"),
+				"rate": 300,
+				"amount": 300,
+			},
+		)
 
 	sales_invoice.set_missing_values()
 	sales_invoice.submit()
 	return sales_invoice
+
+
+def create_imaging_observation_template(name):
+	if frappe.db.exists("Observation Template", name):
+		return frappe.get_doc("Observation Template", name)
+
+	template = frappe.new_doc("Observation Template")
+	template.observation = name
+	template.item_code = name
+	template.observation_category = "Imaging"
+	template.item_group = "Services"
+	template.is_billable = 1
+	template.rate = 300
+	template.abbr = "IMG"
+	template.save()
+	return template
 
 
 def create_patient_encounter(patient, observation_template):

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -344,9 +344,23 @@ def make_observation(service_request, appointment=None):
 		else:
 			observation = create_observation(service_request, appointment)
 
-	diagnostic_report = frappe.db.exists("Diagnostic Report", {"docname": service_request.order_group})
+	create_separate_reports = frappe.db.get_single_value(
+		"Healthcare Settings", "create_separate_diagnostic_report_based_on_observation_category"
+	)
+	observation_category = frappe.db.get_value(
+		"Observation Template", service_request.template_dn, "observation_category"
+	)
+	report_filters = {"docname": service_request.order_group}
+	if create_separate_reports and observation_category:
+		report_filters["observation_category"] = observation_category
+
+	diagnostic_report = frappe.db.exists("Diagnostic Report", report_filters)
 	if not diagnostic_report:
-		insert_diagnostic_report(service_request, sample_collection.name if sample_collection else None)
+		insert_diagnostic_report(
+			service_request,
+			sample_collection.name if sample_collection else None,
+			observation_category=observation_category if create_separate_reports else None,
+		)
 
 	if sample_collection:
 		if diagnostic_report and not frappe.db.get_value(
@@ -401,7 +415,7 @@ def create_observation(service_request, appointment=None):
 	return doc
 
 
-def insert_diagnostic_report(doc, sample_collection=None):
+def insert_diagnostic_report(doc, sample_collection=None, observation_category=None):
 	diagnostic_report = frappe.new_doc("Diagnostic Report")
 	diagnostic_report.company = doc.company
 	diagnostic_report.patient = doc.patient
@@ -409,6 +423,7 @@ def insert_diagnostic_report(doc, sample_collection=None):
 	diagnostic_report.docname = doc.order_group
 	diagnostic_report.practitioner = doc.practitioner
 	diagnostic_report.sample_collection = sample_collection
+	diagnostic_report.observation_category = observation_category
 	diagnostic_report.save(ignore_permissions=True)
 
 

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -231,7 +231,7 @@ def make_lab_test(service_request):
 
 
 @frappe.whitelist()
-def make_observation(service_request, appointment=None):
+def make_observation(service_request: str, appointment: str | None = None):
 	if not service_request:
 		return
 

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1625,6 +1625,9 @@ def company_on_trash(doc, method):
 
 def create_sample_collection_and_observation(doc):
 	meta = frappe.get_meta("Sales Invoice Item", cached=True)
+	create_separate_reports = frappe.db.get_single_value(
+		"Healthcare Settings", "create_separate_diagnostic_report_based_on_observation_category"
+	)
 	diag_report_required = False
 	data = []
 	for item in doc.items:
@@ -1666,6 +1669,7 @@ def create_sample_collection_and_observation(doc):
 				"sample_qty",
 				"has_component",
 				"sample_collection_required",
+				"observation_category",
 			],
 			as_dict=True,
 		)
@@ -1682,6 +1686,7 @@ def create_sample_collection_and_observation(doc):
 		if grouped:
 			out_data = grouped
 
+	diagnostic_categories = set()
 	for grp in out_data:
 		patient = doc.patient
 		if meta.has_field("patient") and grp:
@@ -1695,22 +1700,44 @@ def create_sample_collection_and_observation(doc):
 				) = insert_observation_and_sample_collection(
 					doc, patient, obs, sample_collection, obs.get("child")
 				)
+				if diag_report_required and obs.get("observation_category"):
+					diagnostic_categories.add(obs.get("observation_category"))
 			if sample_collection and len(sample_collection.get("observation_sample_collection")) > 0:
 				sample_collection.save(ignore_permissions=True)
 
 			if diag_report_required:
-				insert_diagnostic_report(doc, patient, sample_collection.name)
+				if create_separate_reports and diagnostic_categories:
+					for observation_category in diagnostic_categories:
+						insert_diagnostic_report(
+							doc,
+							patient,
+							sample_collection.name,
+							observation_category=observation_category,
+						)
+				else:
+					insert_diagnostic_report(doc, patient, sample_collection.name)
 		else:
 			sample_collection, diag_report_required = insert_observation_and_sample_collection(
 				doc, patient, grp, sample_collection
 			)
+			if diag_report_required and grp.get("observation_category"):
+				diagnostic_categories.add(grp.get("observation_category"))
 
 	if not meta.has_field("patient"):
 		if sample_collection and len(sample_collection.get("observation_sample_collection")) > 0:
 			sample_collection.save(ignore_permissions=True)
 
 		if diag_report_required:
-			insert_diagnostic_report(doc, patient, sample_collection.name)
+			if create_separate_reports and diagnostic_categories:
+				for observation_category in diagnostic_categories:
+					insert_diagnostic_report(
+						doc,
+						patient,
+						sample_collection.name,
+						observation_category=observation_category,
+					)
+			else:
+				insert_diagnostic_report(doc, patient, sample_collection.name)
 
 
 def create_sample_collection(doc, patient):
@@ -1726,8 +1753,12 @@ def create_sample_collection(doc, patient):
 	return sample_collection
 
 
-def insert_diagnostic_report(doc, patient, sample_collection=None):
-	if not frappe.db.exists("Diagnostic Report", {"docname": doc.name}):
+def insert_diagnostic_report(doc, patient, sample_collection=None, observation_category=None):
+	filters = {"docname": doc.name}
+	if observation_category:
+		filters["observation_category"] = observation_category
+
+	if not frappe.db.exists("Diagnostic Report", filters):
 		diagnostic_report = frappe.new_doc("Diagnostic Report")
 		diagnostic_report.company = doc.company
 		diagnostic_report.patient = patient
@@ -1735,6 +1766,7 @@ def insert_diagnostic_report(doc, patient, sample_collection=None):
 		diagnostic_report.docname = doc.name
 		diagnostic_report.practitioner = doc.ref_practitioner
 		diagnostic_report.sample_collection = sample_collection
+		diagnostic_report.observation_category = observation_category
 		diagnostic_report.save(ignore_permissions=True)
 
 

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1686,9 +1686,10 @@ def create_sample_collection_and_observation(doc):
 		if grouped:
 			out_data = grouped
 
-	diagnostic_categories = set()
 	for grp in out_data:
 		patient = doc.patient
+		diagnostic_categories = set()
+		patient_diag_report_required = False
 		if meta.has_field("patient") and grp:
 			patient = grp
 		if meta.has_field("patient"):
@@ -1696,16 +1697,19 @@ def create_sample_collection_and_observation(doc):
 			for obs in out_data[grp]:
 				(
 					sample_collection,
-					diag_report_required,
+					current_diag_report_required,
 				) = insert_observation_and_sample_collection(
 					doc, patient, obs, sample_collection, obs.get("child")
 				)
-				if diag_report_required and obs.get("observation_category"):
+				patient_diag_report_required = (
+					patient_diag_report_required or current_diag_report_required
+				)
+				if current_diag_report_required and obs.get("observation_category"):
 					diagnostic_categories.add(obs.get("observation_category"))
 			if sample_collection and len(sample_collection.get("observation_sample_collection")) > 0:
 				sample_collection.save(ignore_permissions=True)
 
-			if diag_report_required:
+			if patient_diag_report_required:
 				if create_separate_reports and diagnostic_categories:
 					for observation_category in diagnostic_categories:
 						insert_diagnostic_report(
@@ -1754,7 +1758,7 @@ def create_sample_collection(doc, patient):
 
 
 def insert_diagnostic_report(doc, patient, sample_collection=None, observation_category=None):
-	filters = {"docname": doc.name}
+	filters = {"docname": doc.name, "patient": patient}
 	if observation_category:
 		filters["observation_category"] = observation_category
 

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1701,9 +1701,7 @@ def create_sample_collection_and_observation(doc):
 				) = insert_observation_and_sample_collection(
 					doc, patient, obs, sample_collection, obs.get("child")
 				)
-				patient_diag_report_required = (
-					patient_diag_report_required or current_diag_report_required
-				)
+				patient_diag_report_required = patient_diag_report_required or current_diag_report_required
 				if current_diag_report_required and obs.get("observation_category"):
 					diagnostic_categories.add(obs.get("observation_category"))
 			if sample_collection and len(sample_collection.get("observation_sample_collection")) > 0:


### PR DESCRIPTION
This enhancement introduces support for creating separate Diagnostic Report records based on Observation Category. The feature is controlled through Healthcare Settings and works consistently across both supported observation-generation workflows:

* Encounter / Service Request–based observation generation
* Sales Invoice observation-generation flow

By default, the feature is disabled, ensuring full backward compatibility with the existing behavior.

Changes

* Renamed the Laboratory tab in Healthcare Settings to Diagnostics.
* Added a new Healthcare Settings option: Create Separate Diagnostic Report Based on Observation Category.
* The new setting is unchecked by default.
* Added descriptive help text explaining that:

  * When enabled, separate Diagnostic Reports are created for each Observation Category.
  * When disabled, the existing single-report behavior is preserved.

Functional Behavior

When Create Separate Diagnostic Report Based on Observation Category is enabled:

* Observations belonging to different categories (such as Laboratory, Imaging, etc.) generate separate Diagnostic Reports.
* Diagnostic Report rendering and status evaluation are restricted to observations belonging to the corresponding Observation Category.
* Category-wise Diagnostic Report generation is supported for:

  * Encounter / Service Request–generated observations.
  * Observations generated through the Sales Invoice submission flow.

When the setting is disabled:

* The existing default behavior remains unchanged.
* A single Diagnostic Report continues to be generated for all observations.

Implementation Details

* Added an internal observation_category field to the Diagnostic Report doctype.
* Updated the Diagnostic Report creation logic to split reports by Observation Category only when the new setting is enabled.
* Updated observation retrieval and status evaluation logic so each Diagnostic Report processes only observations belonging to its own Observation Category.
* Preserved the existing implementation for installations that do not enable the feature.

Supported Scenarios

1. Encounter / Service Request Flow

When observations generated from Encounter or Service Request workflows belong to different Observation Categories, separate Diagnostic Reports are created for each category.

2. Sales Invoice Observation Flow

When observations are generated through Sales Invoice submission and belong to different Observation Categories, separate Diagnostic Reports are created accordingly.

Testing

The following scenarios were verified:

1. Encounter-based observation generation with category-wise Diagnostic Report creation.
2. Sales Invoice–based observation generation with category-wise Diagnostic Report creation.
3. Existing single-report behavior when the setting is disabled.
4. Regression testing for the Sales Invoice workflow to ensure multiple Observation Categories correctly generate multiple Diagnostic Reports.

Note

* No change in default behavior unless the Create Separate Diagnostic Report Based on Observation Category setting is enabled.
* Existing implementations continue to function without modification, preserving backward compatibility for users relying on the current single Diagnostic Report workflow.



<img width="1843" height="135" alt="diag1" src="https://github.com/user-attachments/assets/d39a3804-82b0-4b76-8ca8-59132fad4b45" />
<img width="1878" height="99" alt="diag2" src="https://github.com/user-attachments/assets/bbd47d67-aa80-4ea5-b746-332a23a025c5" />
<img width="824" height="214" alt="diag3" src="https://github.com/user-attachments/assets/208d19ae-11a6-41d0-bf60-29b9ffc5e0da" />
<img width="884" height="230" alt="diag4" src="https://github.com/user-attachments/assets/5d4d3c30-5366-4e74-9678-9a7fca61962c" />

no-docs
Closes issue #961 