### PR TITLE
fix: resolve rate 0 for healthcare services in Sales Invoice (v16 erpnext)

### DIFF
--- a/healthcare/healthcare/custom_doctype/sales_invoice.py
+++ b/healthcare/healthcare/custom_doctype/sales_invoice.py
@@ -25,6 +25,7 @@ class SalesInvoiceMixin:
 					"customer": frappe.db.get_value("Patient", self.patient, "customer"),
 					"selling_price_list": self.selling_price_list or price_list,
 					"price_list_currency": self.currency or price_list_currency,
+				"currency": self.currency or price_list_currency,
 					"plc_conversion_rate": 1.0,
 					"conversion_rate": 1.0,
 				}
@@ -39,7 +40,20 @@ class SalesInvoiceMixin:
 			if checked_item.get("rate"):
 				item_line.rate = checked_item.get("rate")
 			else:
-				item_line.rate = item_details.price_list_rate
+				rate = item_details.price_list_rate
+				if not rate:
+					# v16 erpnext get_item_details strips uom; re-fetch Item Price rate
+					selling_price_list = self.selling_price_list or price_list
+					rate = frappe.db.get_value(
+						"Item Price",
+						{"item_code": checked_item.get("item"), "price_list": selling_price_list, "customer": ""},
+						"price_list_rate",
+					) or frappe.db.get_value(
+						"Item Price",
+						{"item_code": checked_item.get("item"), "price_list": selling_price_list},
+						"price_list_rate",
+					)
+				item_line.rate = rate
 
 			if checked_item.get("income_account"):
 				item_line.income_account = checked_item.get("income_account")


### PR DESCRIPTION
## Summary
On v16 erpnext, healthcare service lines added via `Sales Invoice.set_healthcare_services()` are created with `rate = 0`.

## Root cause
`set_healthcare_services` builds an `ItemDetailsCtx` and calls `get_item_details()`. On v16 erpnext, `get_price_list_rate_for` is wrapped with `@normalize_ctx_input(ItemDetailsCtx)`, which pops `uom`/`stock_uom` from the context before `get_item_price()` runs. `get_item_price()` filters `IfNull(ip.uom, "") in ("", pctx.uom)`; with `pctx.uom = None` it matches no Item Price, so `price_list_rate` comes back as `0`. The healthcare Item Price is stored per-uom (`uom = "Unit"`), so the rate can never be resolved this way on v16.

Note: the `currency` line added on `develop` alone does **not** resolve this on v16 erpnext — the uom strip is the blocker.

## Fix
- Forward `currency` to the context (matches `develop`).
- After `get_item_details()`, if `price_list_rate` is still falsy, re-fetch the rate directly from `Item Price` for the resolved selling price list (with and without a customer filter). This guarantees the correct rate regardless of the erpnext version's normalize behaviour.

## Test plan
- Create a Sales Invoice for a patient, set the selling price list, call `set_healthcare_services([{"item": "<healthcare item>"}])`.
- The item line `rate` should equal the Item Price rate (e.g. `800` for `LT-CBC`), not `0`.
