### PR TITLE
feat(ipmo): add stop medication order button for inpatient medication orders

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.js
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.js
@@ -1,6 +1,54 @@
 // Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
+function prompt_to_remove_stopped_rows(frm) {
+	if (frm.doc.docstatus !== 0 || !(frm.doc.medication_orders || []).length || frm.__stopped_row_prompt_open) {
+		return;
+	}
+
+	frappe.call({
+		method: "get_stopped_linked_rows",
+		doc: frm.doc,
+		callback: function (r) {
+			const stopped_rows = r.message || [];
+			if (!stopped_rows.length) {
+				return;
+			}
+
+			frm.__stopped_row_prompt_open = true;
+			const message =
+				stopped_rows.length === 1
+					? __("1 medication row in this draft entry was stopped in the linked Inpatient Medication Order. Do you want to remove it now?")
+					: __(
+						"{0} medication rows in this draft entry were stopped in the linked Inpatient Medication Order. Do you want to remove them now?",
+						[stopped_rows.length],
+					);
+
+			frappe.confirm(
+				message,
+				() => {
+					const rows_to_remove = new Set(stopped_rows.map((row) => row.name));
+					const remaining_rows = (frm.doc.medication_orders || [])
+						.filter((row) => !rows_to_remove.has(row.name))
+						.map((row) => ({ ...row }));
+					frappe.model.clear_table(frm.doc, "medication_orders");
+					remaining_rows.forEach((row) => frm.add_child("medication_orders", row));
+					frm.refresh_field("medication_orders");
+					frm.dirty();
+					frm.__stopped_row_prompt_open = false;
+				},
+				() => {
+					frm.__stopped_row_prompt_open = false;
+					frappe.show_alert({
+						message: __("Stopped medication rows were kept in draft. Remove them before saving or submitting."),
+						indicator: "orange",
+					});
+				},
+			);
+		},
+	});
+}
+
 frappe.ui.form.on("Inpatient Medication Entry", {
 	refresh: function (frm) {
 		// Ignore cancellation of doctype on cancel all
@@ -31,8 +79,9 @@ frappe.ui.form.on("Inpatient Medication Entry", {
 			};
 		});
 
-		if (frm.doc.__islocal || frm.doc.docstatus !== 0 || !frm.doc.update_stock)
-			return;
+		prompt_to_remove_stopped_rows(frm);
+
+		if (frm.doc.__islocal || frm.doc.docstatus !== 0 || !frm.doc.update_stock) return;
 
 		frm.add_custom_button(__("Make Stock Entry"), function () {
 			frappe.call({
@@ -69,6 +118,7 @@ frappe.ui.form.on("Inpatient Medication Entry", {
 			freeze_message: __("Fetching Pending Medication Orders"),
 			callback: function () {
 				refresh_field("medication_orders");
+				prompt_to_remove_stopped_rows(frm);
 			},
 		});
 	},

--- a/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.js
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.js
@@ -2,7 +2,11 @@
 // For license information, please see license.txt
 
 function prompt_to_remove_stopped_rows(frm) {
-	if (frm.doc.docstatus !== 0 || !(frm.doc.medication_orders || []).length || frm.__stopped_row_prompt_open) {
+	if (
+		frm.doc.docstatus !== 0 ||
+		!(frm.doc.medication_orders || []).length ||
+		frm.__stopped_row_prompt_open
+	) {
 		return;
 	}
 
@@ -18,21 +22,25 @@ function prompt_to_remove_stopped_rows(frm) {
 			frm.__stopped_row_prompt_open = true;
 			const message =
 				stopped_rows.length === 1
-					? __("1 medication row in this draft entry was stopped in the linked Inpatient Medication Order. Do you want to remove it now?")
+					? __(
+							"1 medication row in this draft entry was stopped in the linked Inpatient Medication Order. Do you want to remove it now?",
+					  )
 					: __(
-						"{0} medication rows in this draft entry were stopped in the linked Inpatient Medication Order. Do you want to remove them now?",
-						[stopped_rows.length],
-					);
+							"{0} medication rows in this draft entry were stopped in the linked Inpatient Medication Order. Do you want to remove them now?",
+							[stopped_rows.length],
+					  );
 
 			frappe.confirm(
 				message,
 				() => {
-					const rows_to_remove = new Set(stopped_rows.map((row) => row.name));
+					const rows_to_remove = new Set(stopped_rows.map(row => row.name));
 					const remaining_rows = (frm.doc.medication_orders || [])
-						.filter((row) => !rows_to_remove.has(row.name))
-						.map((row) => ({ ...row }));
+						.filter(row => !rows_to_remove.has(row.name))
+						.map(row => ({ ...row }));
 					frappe.model.clear_table(frm.doc, "medication_orders");
-					remaining_rows.forEach((row) => frm.add_child("medication_orders", row));
+					remaining_rows.forEach(row =>
+						frm.add_child("medication_orders", row),
+					);
 					frm.refresh_field("medication_orders");
 					frm.dirty();
 					frm.__stopped_row_prompt_open = false;
@@ -40,7 +48,9 @@ function prompt_to_remove_stopped_rows(frm) {
 				() => {
 					frm.__stopped_row_prompt_open = false;
 					frappe.show_alert({
-						message: __("Stopped medication rows were kept in draft. Remove them before saving or submitting."),
+						message: __(
+							"Stopped medication rows were kept in draft. Remove them before saving or submitting.",
+						),
 						indicator: "orange",
 					});
 				},
@@ -81,7 +91,8 @@ frappe.ui.form.on("Inpatient Medication Entry", {
 
 		prompt_to_remove_stopped_rows(frm);
 
-		if (frm.doc.__islocal || frm.doc.docstatus !== 0 || !frm.doc.update_stock) return;
+		if (frm.doc.__islocal || frm.doc.docstatus !== 0 || !frm.doc.update_stock)
+			return;
 
 		frm.add_custom_button(__("Make Stock Entry"), function () {
 			frappe.call({

--- a/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.py
@@ -78,12 +78,36 @@ class InpatientMedicationEntry(Document):
 					).format(entry.idx, get_link_to_form(entry.against_imo))
 				)
 
-				if status in {"Stopped", "Completed"} or (status != "Stopped" and is_completed):
-					frappe.throw(
-						_("Row {0}: This Medication Order is already marked as {1}").format(
-							entry.idx, "stopped" if status == "Stopped" else "completed"
-						)
+			if status in {"Stopped", "Completed"} or (status != "Stopped" and is_completed):
+				frappe.throw(
+					_("Row {0}: This Medication Order is already marked as {1}").format(
+						entry.idx, "stopped" if status == "Stopped" else "completed"
 					)
+				)
+
+	@frappe.whitelist()
+	def get_stopped_linked_rows(self):
+		stopped_rows = []
+
+		for entry in self.medication_orders:
+			if not entry.against_imoe:
+				continue
+
+			status = frappe.db.get_value("Inpatient Medication Order Entry", entry.against_imoe, "status")
+			if status != "Stopped":
+				continue
+
+			stopped_rows.append(
+				{
+					"name": entry.name,
+					"idx": entry.idx,
+					"against_imoe": entry.against_imoe,
+					"drug_code": entry.drug_code,
+					"drug_name": entry.drug_name,
+				}
+			)
+
+		return stopped_rows
 
 	def on_cancel(self):
 		self.cancel_stock_entries()

--- a/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.py
@@ -78,15 +78,12 @@ class InpatientMedicationEntry(Document):
 					).format(entry.idx, get_link_to_form(entry.against_imo))
 				)
 
-			if status == "Stopped":
-				frappe.throw(
-					_("Row {0}: This Medication Order is already marked as stopped").format(entry.idx)
-				)
-
-			if is_completed or status == "Completed":
-				frappe.throw(
-					_("Row {0}: This Medication Order is already marked as completed").format(entry.idx)
-				)
+				if status in {"Stopped", "Completed"} or (status != "Stopped" and is_completed):
+					frappe.throw(
+						_("Row {0}: This Medication Order is already marked as {1}").format(
+							entry.idx, "stopped" if status == "Stopped" else "completed"
+						)
+					)
 
 	def on_cancel(self):
 		self.cancel_stock_entries()

--- a/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.py
@@ -65,8 +65,10 @@ class InpatientMedicationEntry(Document):
 
 	def validate_medication_orders(self):
 		for entry in self.medication_orders:
-			docstatus, is_completed = frappe.db.get_value(
-				"Inpatient Medication Order Entry", entry.against_imoe, ["docstatus", "is_completed"]
+			docstatus, is_completed, status = frappe.db.get_value(
+				"Inpatient Medication Order Entry",
+				entry.against_imoe,
+				["docstatus", "is_completed", "status"],
 			)
 
 			if docstatus == 2:
@@ -76,7 +78,12 @@ class InpatientMedicationEntry(Document):
 					).format(entry.idx, get_link_to_form(entry.against_imo))
 				)
 
-			if is_completed:
+			if status == "Stopped":
+				frappe.throw(
+					_("Row {0}: This Medication Order is already marked as stopped").format(entry.idx)
+				)
+
+			if is_completed or status == "Completed":
 				frappe.throw(
 					_("Row {0}: This Medication Order is already marked as completed").format(entry.idx)
 				)
@@ -93,54 +100,36 @@ class InpatientMedicationEntry(Document):
 		return self.make_stock_entry()
 
 	def update_medication_orders(self, on_cancel=False):
-		orders, order_entry_map = self.get_order_entry_map()
+		orders, order_parents = self.get_order_entry_map()
 
 		if not orders:
 			return
 
 		is_completed = 0 if on_cancel else 1
+		entry_status = "Pending" if on_cancel else "Completed"
 
 		order_entry = frappe.qb.DocType("Inpatient Medication Order Entry")
 
 		(
 			frappe.qb.update(order_entry)
 			.set(order_entry.is_completed, is_completed)
+			.set(order_entry.status, entry_status)
 			.where(order_entry.name.isin(orders))
 		).run()
 
-		# update status and completed orders count
-		for order, count in order_entry_map.items():
+		for order in order_parents:
 			medication_order = frappe.get_doc("Inpatient Medication Order", order)
-			completed_orders = flt(count)
-			current_value = frappe.db.get_value(
-				"Inpatient Medication Order",
-				order,
-				"completed_orders",
-			)
-
-			if on_cancel:
-				completed_orders = flt(current_value) - flt(count)
-			else:
-				completed_orders = flt(current_value) + flt(count)
-
-			medication_order.db_set("completed_orders", completed_orders)
-			medication_order.set_status()
+			medication_order.set_status(update=True)
 
 	def get_order_entry_map(self):
-		# for marking order completion status
 		orders = []
-		# orders mapped
-		order_entry_map = dict()
+		order_parents = set()
 
 		for entry in self.medication_orders:
 			orders.append(entry.against_imoe)
-			parent = entry.against_imo
-			if not order_entry_map.get(parent):
-				order_entry_map[parent] = 0
+			order_parents.add(entry.against_imo)
 
-			order_entry_map[parent] += 1
-
-		return orders, order_entry_map
+		return orders, order_parents
 
 	def check_stock_qty(self):
 		drug_shortage = get_drug_shortage_map(self.medication_orders, self.warehouse)
@@ -234,6 +223,11 @@ def get_pending_medication_orders(entry):
 		.where(inpatient_medication_order.docstatus == 1)
 		.where(inpatient_medication_order.company == entry.company)
 		.where(medication_order_entry.is_completed == 0)
+		.where(
+			medication_order_entry.status.isnull()
+			| (medication_order_entry.status == "")
+			| (medication_order_entry.status == "Pending")
+		)
 		.orderby(medication_order_entry.date)
 		.orderby(medication_order_entry.time)
 	)

--- a/healthcare/healthcare/doctype/inpatient_medication_entry/test_inpatient_medication_entry.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/test_inpatient_medication_entry.py
@@ -82,6 +82,36 @@ class TestInpatientMedicationEntry(HealthcareTestSuite):
 
 		self.assertEqual(len(ipme.medication_orders), 5)
 
+	def test_stopped_linked_rows_are_returned_for_draft_cleanup(self):
+		ipmo = create_ipmo(self.patient)
+		ipmo.submit()
+
+		filters = frappe._dict(from_date=getdate(), to_date=getdate(), from_time="", to_time="", patient=self.patient)
+		draft_ipme = create_ipme(filters, update_stock=0)
+		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == getdate()]
+
+		ipmo.stop_pending_order_entries("Doctor stopped remaining medication", selected_entries)
+		stopped_rows = draft_ipme.get_stopped_linked_rows()
+
+		self.assertEqual(len(stopped_rows), len(selected_entries))
+		self.assertTrue(all(row.get("against_imoe") in selected_entries for row in stopped_rows))
+
+	def test_draft_ipme_save_is_blocked_for_stopped_rows(self):
+		ipmo = create_ipmo(self.patient)
+		ipmo.submit()
+
+		filters = frappe._dict(from_date=getdate(), to_date=getdate(), from_time="", to_time="", patient=self.patient)
+		draft_ipme = create_ipme(filters, update_stock=0)
+		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == getdate()]
+
+		ipmo.stop_pending_order_entries("Doctor stopped remaining medication", selected_entries)
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"already marked as stopped",
+			draft_ipme.insert,
+		)
+
 	def test_ipme_with_stock_update(self):
 		ipmo = create_ipmo(self.patient)
 		ipmo.submit()

--- a/healthcare/healthcare/doctype/inpatient_medication_entry/test_inpatient_medication_entry.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/test_inpatient_medication_entry.py
@@ -89,6 +89,7 @@ class TestInpatientMedicationEntry(HealthcareTestSuite):
 		filters = frappe._dict(
 			from_date=getdate(), to_date=getdate(), from_time="", to_time="", patient=self.patient
 		)
+		draft_ipme = create_ipme(filters, update_stock=0)
 		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == getdate()]
 
 		ipmo.stop_pending_order_entries("Doctor stopped remaining medication", selected_entries)
@@ -104,6 +105,7 @@ class TestInpatientMedicationEntry(HealthcareTestSuite):
 		filters = frappe._dict(
 			from_date=getdate(), to_date=getdate(), from_time="", to_time="", patient=self.patient
 		)
+		draft_ipme = create_ipme(filters, update_stock=0)
 		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == getdate()]
 
 		ipmo.stop_pending_order_entries("Doctor stopped remaining medication", selected_entries)

--- a/healthcare/healthcare/doctype/inpatient_medication_entry/test_inpatient_medication_entry.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/test_inpatient_medication_entry.py
@@ -199,4 +199,3 @@ def make_stock_entry(warehouse=None):
 	se_child.conversion_factor = 1.0
 	se_child.expense_account = expense_account
 	stock_entry.submit()
-

--- a/healthcare/healthcare/doctype/inpatient_medication_entry/test_inpatient_medication_entry.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/test_inpatient_medication_entry.py
@@ -86,8 +86,9 @@ class TestInpatientMedicationEntry(HealthcareTestSuite):
 		ipmo = create_ipmo(self.patient)
 		ipmo.submit()
 
-		filters = frappe._dict(from_date=getdate(), to_date=getdate(), from_time="", to_time="", patient=self.patient)
-		draft_ipme = create_ipme(filters, update_stock=0)
+		filters = frappe._dict(
+			from_date=getdate(), to_date=getdate(), from_time="", to_time="", patient=self.patient
+		)
 		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == getdate()]
 
 		ipmo.stop_pending_order_entries("Doctor stopped remaining medication", selected_entries)
@@ -100,8 +101,9 @@ class TestInpatientMedicationEntry(HealthcareTestSuite):
 		ipmo = create_ipmo(self.patient)
 		ipmo.submit()
 
-		filters = frappe._dict(from_date=getdate(), to_date=getdate(), from_time="", to_time="", patient=self.patient)
-		draft_ipme = create_ipme(filters, update_stock=0)
+		filters = frappe._dict(
+			from_date=getdate(), to_date=getdate(), from_time="", to_time="", patient=self.patient
+		)
 		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == getdate()]
 
 		ipmo.stop_pending_order_entries("Doctor stopped remaining medication", selected_entries)

--- a/healthcare/healthcare/doctype/inpatient_medication_entry/test_inpatient_medication_entry.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/test_inpatient_medication_entry.py
@@ -65,6 +65,23 @@ class TestInpatientMedicationEntry(HealthcareTestSuite):
 		self.assertEqual(len(ipme.medication_orders), 3)
 		self.assertEqual(getdate(ipme.medication_orders[0].datetime), date)
 
+	def test_stopped_rows_are_excluded_from_pending_fetch(self):
+		ipmo = create_ipmo(self.patient)
+		ipmo.submit()
+		frappe.db.set_value(
+			"Inpatient Medication Order Entry",
+			ipmo.medication_orders[0].name,
+			{"status": "Stopped", "stop_reason": "Doctor stopped first slot"},
+			update_modified=False,
+		)
+		ipmo.reload()
+		ipmo.set_status(update=True)
+
+		filters = frappe._dict(from_date="", to_date="", from_time="", to_time="", patient=self.patient)
+		ipme = create_ipme(filters, update_stock=0)
+
+		self.assertEqual(len(ipme.medication_orders), 5)
+
 	def test_ipme_with_stock_update(self):
 		ipmo = create_ipmo(self.patient)
 		ipmo.submit()
@@ -89,7 +106,11 @@ class TestInpatientMedicationEntry(HealthcareTestSuite):
 		is_order_completed = frappe.db.get_value(
 			"Inpatient Medication Order Entry", ipme.medication_orders[0].against_imoe, "is_completed"
 		)
+		order_status = frappe.db.get_value(
+			"Inpatient Medication Order Entry", ipme.medication_orders[0].against_imoe, "status"
+		)
 		self.assertEqual(is_order_completed, 1)
+		self.assertEqual(order_status, "Completed")
 
 		# test stock entry
 		stock_entry = frappe.db.exists("Stock Entry", {"inpatient_medication_entry": ipme.name})
@@ -178,3 +199,4 @@ def make_stock_entry(warehouse=None):
 	se_child.conversion_factor = 1.0
 	se_child.expense_account = expense_account
 	stock_entry.submit()
+

--- a/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.js
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.js
@@ -9,6 +9,7 @@ frappe.ui.form.on("Inpatient Medication Order", {
 
 		frm.events.show_medication_order_button(frm);
 		frm.events.show_get_from_encounter_button(frm);
+		frm.events.show_stop_medication_button(frm);
 
 		frm.set_query("patient", () => {
 			return {
@@ -109,20 +110,145 @@ frappe.ui.form.on("Inpatient Medication Order", {
 		);
 	},
 
+	show_stop_medication_button: function (frm) {
+		if (frm.doc.docstatus !== 1 || frm.doc.status === "Completed") {
+			return;
+		}
+
+		frm.add_custom_button(__("Stop Medication Order"), () => {
+			frm.call({
+				doc: frm.doc,
+				method: "get_pending_order_entries_for_stop",
+				freeze: true,
+				freeze_message: __("Fetching Pending Medication Orders"),
+				callback: function (r) {
+					const pending_orders = r.message || [];
+					if (!pending_orders.length) {
+						frappe.msgprint(__("No pending medication orders found to stop."));
+						return;
+					}
+
+					const dialog = new frappe.ui.Dialog({
+						title: __("Stop Pending Medication Orders"),
+						fields: [
+							{
+								fieldname: "stop_help",
+								fieldtype: "HTML",
+								options: `<div class="small text-muted" style="margin-bottom: 10px;">${__("Select the pending medication dates you want to stop.")}</div>`,
+							},
+							{
+								label: __("Pending Medication Orders"),
+								fieldname: "pending_orders",
+								fieldtype: "Table",
+								cannot_add_rows: true,
+								cannot_delete_rows: true,
+								in_place_edit: false,
+								reqd: 1,
+								data: pending_orders.map((row) => ({
+									order_entry_name: row.name,
+									drug_name: row.drug_name || row.drug,
+									dosage: row.dosage,
+									date: row.date,
+									time: row.time,
+								})),
+								fields: [
+									{
+										fieldname: "order_entry_name",
+										fieldtype: "Data",
+										hidden: 1,
+									},
+									{
+										fieldname: "drug_name",
+										fieldtype: "Data",
+										label: __("Drug"),
+										in_list_view: 1,
+										read_only: 1,
+									},
+									{
+										fieldname: "dosage",
+										fieldtype: "Data",
+										label: __("Dosage"),
+										in_list_view: 1,
+										read_only: 1,
+									},
+									{
+										fieldname: "date",
+										fieldtype: "Date",
+										label: __("Date"),
+										in_list_view: 1,
+										read_only: 1,
+									},
+									{
+										fieldname: "time",
+										fieldtype: "Time",
+										label: __("Time"),
+										in_list_view: 1,
+										read_only: 1,
+									},
+								],
+							},
+							{
+								fieldname: "reason",
+								label: __("Reason"),
+								fieldtype: "Small Text",
+								reqd: 1,
+							},
+						],
+						primary_action_label: __("Stop Pending Orders"),
+						primary_action(values) {
+							const selected_rows = dialog.fields_dict.pending_orders.grid.get_selected_children();
+							const selected_entry_names = selected_rows.map((row) => row.order_entry_name);
+
+							if (!selected_entry_names.length) {
+								frappe.throw(__("Please select at least one pending medication order to stop."));
+							}
+
+							frm.call({
+								doc: frm.doc,
+								method: "stop_pending_order_entries",
+								args: { reason: values.reason, order_entry_names: selected_entry_names },
+								freeze: true,
+								freeze_message: __("Stopping Pending Medication Orders"),
+								callback: function () {
+									dialog.hide();
+									frm.reload_doc();
+								},
+							});
+						},
+					});
+
+					dialog.show();
+					dialog.fields_dict.pending_orders.grid.refresh();
+					dialog.fields_dict.pending_orders.grid.wrapper.find(".grid-remove-rows").hide();
+					dialog.fields_dict.pending_orders.grid.wrapper.find(".grid-remove-all-rows").hide();
+					dialog.$wrapper.find(".modal-dialog").css("max-width", "900px");
+				},
+			});
+		});
+	},
+
 	show_progress: function (frm) {
 		let bars = [];
 		let message = "";
+		let total_orders = frm.doc.total_orders || 0;
+		let closed_orders = frm.doc.completed_orders || 0;
 
-		// completed sessions
-		let title = __("{0} medication orders completed", [frm.doc.completed_orders]);
-		if (frm.doc.completed_orders === 1) {
-			title = __("{0} medication order completed", [frm.doc.completed_orders]);
+		if (frm.doc.medication_orders && frm.doc.medication_orders.length) {
+			total_orders = frm.doc.medication_orders.length;
+			closed_orders = frm.doc.medication_orders.filter(
+				(row) => ["Completed", "Stopped"].includes(row.status || (row.is_completed ? "Completed" : "Pending")),
+			).length;
 		}
-		title += __(" out of {0}", [frm.doc.total_orders]);
+
+		let title = __("{0} medication orders closed", [closed_orders]);
+		if (closed_orders === 1) {
+			title = __("{0} medication order closed", [closed_orders]);
+		}
+		title += __(" out of {0}", [total_orders]);
 
 		bars.push({
 			title: title,
-			width: (frm.doc.completed_orders / frm.doc.total_orders) * 100 + "%",
+			width: total_orders ? (closed_orders / total_orders) * 100 + "%" : "0%",
 			progress_class: "progress-bar-success",
 		});
 		if (bars[0].width == "0%") {

--- a/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.js
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.js
@@ -124,7 +124,9 @@ frappe.ui.form.on("Inpatient Medication Order", {
 				callback: function (r) {
 					const pending_orders = r.message || [];
 					if (!pending_orders.length) {
-						frappe.msgprint(__("No pending medication orders found to stop."));
+						frappe.msgprint(
+							__("No pending medication orders found to stop."),
+						);
 						return;
 					}
 
@@ -134,7 +136,9 @@ frappe.ui.form.on("Inpatient Medication Order", {
 							{
 								fieldname: "stop_help",
 								fieldtype: "HTML",
-								options: `<div class="small text-muted" style="margin-bottom: 10px;">${__("Select the pending medication dates you want to stop.")}</div>`,
+								options: `<div class="small text-muted" style="margin-bottom: 10px;">${__(
+									"Select the pending medication dates you want to stop.",
+								)}</div>`,
 							},
 							{
 								label: __("Pending Medication Orders"),
@@ -144,7 +148,7 @@ frappe.ui.form.on("Inpatient Medication Order", {
 								cannot_delete_rows: true,
 								in_place_edit: false,
 								reqd: 1,
-								data: pending_orders.map((row) => ({
+								data: pending_orders.map(row => ({
 									order_entry_name: row.name,
 									drug_name: row.drug_name || row.drug,
 									dosage: row.dosage,
@@ -196,19 +200,31 @@ frappe.ui.form.on("Inpatient Medication Order", {
 						],
 						primary_action_label: __("Stop Pending Orders"),
 						primary_action(values) {
-							const selected_rows = dialog.fields_dict.pending_orders.grid.get_selected_children();
-							const selected_entry_names = selected_rows.map((row) => row.order_entry_name);
+							const selected_rows =
+								dialog.fields_dict.pending_orders.grid.get_selected_children();
+							const selected_entry_names = selected_rows.map(
+								row => row.order_entry_name,
+							);
 
 							if (!selected_entry_names.length) {
-								frappe.throw(__("Please select at least one pending medication order to stop."));
+								frappe.throw(
+									__(
+										"Please select at least one pending medication order to stop.",
+									),
+								);
 							}
 
 							frm.call({
 								doc: frm.doc,
 								method: "stop_pending_order_entries",
-								args: { reason: values.reason, order_entry_names: selected_entry_names },
+								args: {
+									reason: values.reason,
+									order_entry_names: selected_entry_names,
+								},
 								freeze: true,
-								freeze_message: __("Stopping Pending Medication Orders"),
+								freeze_message: __(
+									"Stopping Pending Medication Orders",
+								),
 								callback: function () {
 									dialog.hide();
 									frm.reload_doc();
@@ -219,8 +235,12 @@ frappe.ui.form.on("Inpatient Medication Order", {
 
 					dialog.show();
 					dialog.fields_dict.pending_orders.grid.refresh();
-					dialog.fields_dict.pending_orders.grid.wrapper.find(".grid-remove-rows").hide();
-					dialog.fields_dict.pending_orders.grid.wrapper.find(".grid-remove-all-rows").hide();
+					dialog.fields_dict.pending_orders.grid.wrapper
+						.find(".grid-remove-rows")
+						.hide();
+					dialog.fields_dict.pending_orders.grid.wrapper
+						.find(".grid-remove-all-rows")
+						.hide();
 					dialog.$wrapper.find(".modal-dialog").css("max-width", "900px");
 				},
 			});
@@ -235,8 +255,10 @@ frappe.ui.form.on("Inpatient Medication Order", {
 
 		if (frm.doc.medication_orders && frm.doc.medication_orders.length) {
 			total_orders = frm.doc.medication_orders.length;
-			closed_orders = frm.doc.medication_orders.filter(
-				(row) => ["Completed", "Stopped"].includes(row.status || (row.is_completed ? "Completed" : "Pending")),
+			closed_orders = frm.doc.medication_orders.filter(row =>
+				["Completed", "Stopped"].includes(
+					row.status || (row.is_completed ? "Completed" : "Pending"),
+				),
 			).length;
 		}
 

--- a/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
@@ -3,6 +3,7 @@
 
 
 import frappe
+from typing import Any
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cstr
@@ -120,7 +121,7 @@ class InpatientMedicationOrder(Document):
 		return self.get_pending_order_entries()
 
 	@frappe.whitelist()
-	def stop_pending_order_entries(self, reason, order_entry_names=None):
+	def stop_pending_order_entries(self, reason: str, order_entry_names: list[str] | str | None = None):
 		self.check_permission("write")
 
 		if self.docstatus != 1:
@@ -212,7 +213,7 @@ class InpatientMedicationOrder(Document):
 				frappe.delete_doc("Inpatient Medication Entry", ipme.name, ignore_permissions=True)
 
 	@frappe.whitelist()
-	def add_order_entries(self, order):
+	def add_order_entries(self, order: dict[str, Any]):
 		if order.get("drug_code"):
 			dosage = frappe.get_doc("Prescription Dosage", order.get("dosage"))
 			dates = get_prescription_dates(order.get("period"), self.start_date)

--- a/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
@@ -121,6 +121,8 @@ class InpatientMedicationOrder(Document):
 
 	@frappe.whitelist()
 	def stop_pending_order_entries(self, reason, order_entry_names=None):
+		self.check_permission("write")
+
 		if self.docstatus != 1:
 			frappe.throw(_("Only submitted Inpatient Medication Orders can be stopped."))
 
@@ -133,9 +135,26 @@ class InpatientMedicationOrder(Document):
 			frappe.throw(_("No pending medication orders found to stop."))
 
 		order_entry_names = frappe.parse_json(order_entry_names) if order_entry_names else []
-		selected_entry_names = [entry_name for entry_name in order_entry_names if entry_name in pending_entry_names]
+		selected_entry_names = [
+			entry_name for entry_name in order_entry_names if entry_name in pending_entry_names
+		]
 		if not selected_entry_names:
 			frappe.throw(_("Please select at least one pending medication order to stop."))
+
+		selected_entries = frappe.get_all(
+			"Inpatient Medication Order Entry",
+			filters={"name": ("in", selected_entry_names), "parent": self.name},
+			fields=["name", "status"],
+		)
+		selected_status_map = {entry.name: entry.status or "Pending" for entry in selected_entries}
+		if len(selected_status_map) != len(selected_entry_names) or any(
+			selected_status_map.get(entry_name) != "Pending" for entry_name in selected_entry_names
+		):
+			frappe.throw(
+				_(
+					"Some selected medication rows are no longer pending. Please refresh the document and try again."
+				)
+			)
 
 		self.remove_rows_from_draft_ipme(selected_entry_names)
 
@@ -162,7 +181,6 @@ class InpatientMedicationOrder(Document):
 			ipme_map.setdefault(ref.parent, set()).add(ref.against_imoe)
 
 		return ipme_map
-
 
 	def remove_rows_from_draft_ipme(self, order_entry_names):
 		ipme_map = self.get_ipme_map_for_rows(order_entry_names)
@@ -218,4 +236,3 @@ class InpatientMedicationOrder(Document):
 			return
 		for drug in patient_encounter.drug_prescription:
 			self.add_order_entries(drug)
-

--- a/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
@@ -158,8 +158,6 @@ class InpatientMedicationOrder(Document):
 				)
 			)
 
-		self.remove_rows_from_draft_ipme(selected_entry_names)
-
 		for entry_name in selected_entry_names:
 			frappe.db.set_value(
 				"Inpatient Medication Order Entry",
@@ -170,48 +168,6 @@ class InpatientMedicationOrder(Document):
 
 		self.reload()
 		self.set_status(update=True)
-
-	def get_ipme_map_for_rows(self, order_entry_names):
-		entry_refs = frappe.get_all(
-			"Inpatient Medication Entry Detail",
-			filters={"against_imoe": ("in", order_entry_names)},
-			fields=["parent", "against_imoe"],
-		)
-
-		ipme_map = {}
-		for ref in entry_refs:
-			ipme_map.setdefault(ref.parent, set()).add(ref.against_imoe)
-
-		return ipme_map
-
-	def remove_rows_from_draft_ipme(self, order_entry_names):
-		ipme_map = self.get_ipme_map_for_rows(order_entry_names)
-
-		for ipme_name, linked_order_entries in ipme_map.items():
-			ipme = frappe.get_doc("Inpatient Medication Entry", ipme_name)
-
-			if ipme.docstatus == 1:
-				frappe.throw(
-					_(
-						"Some selected medication rows are already administered in submitted Inpatient Medication Entry {0}. Please refresh the document and try again."
-					).format(frappe.bold(ipme.name))
-				)
-
-			if ipme.docstatus == 2:
-				continue
-
-			remaining_rows = [
-				row for row in ipme.medication_orders if row.against_imoe not in linked_order_entries
-			]
-
-			if len(remaining_rows) == len(ipme.medication_orders):
-				continue
-
-			ipme.set("medication_orders", remaining_rows)
-			if remaining_rows:
-				ipme.save(ignore_permissions=True)
-			else:
-				frappe.delete_doc("Inpatient Medication Entry", ipme.name, ignore_permissions=True)
 
 	@frappe.whitelist()
 	def add_order_entries(self, order: dict[str, Any] | Document):

--- a/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
@@ -16,15 +16,16 @@ class InpatientMedicationOrder(Document):
 	def validate(self):
 		self.validate_inpatient()
 		self.validate_duplicate()
-		self.set_total_orders()
+		self.normalize_order_entry_statuses()
 		self.set_status()
 
 	def on_submit(self):
 		self.validate_inpatient()
-		self.set_status()
+		self.normalize_order_entry_statuses()
+		self.set_status(update=True)
 
 	def on_cancel(self):
-		self.set_status()
+		self.set_status(update=True)
 
 	def validate_inpatient(self):
 		if not self.inpatient_record:
@@ -50,21 +51,147 @@ class InpatientMedicationOrder(Document):
 				frappe.DuplicateEntryError,
 			)
 
-	def set_total_orders(self):
-		self.db_set("total_orders", len(self.medication_orders))
+	def normalize_order_entry_statuses(self):
+		for entry in self.medication_orders:
+			if not entry.status:
+				entry.status = "Completed" if entry.is_completed else "Pending"
 
-	def set_status(self):
+	def get_order_entry_status(self, entry):
+		return entry.status or ("Completed" if entry.is_completed else "Pending")
+
+	def set_total_orders(self):
+		self.total_orders = len(self.medication_orders)
+
+	def set_completed_orders(self):
+		self.completed_orders = sum(
+			1 for entry in self.medication_orders if self.get_order_entry_status(entry) != "Pending"
+		)
+
+	def set_status(self, update=False):
+		self.set_total_orders()
+		self.set_completed_orders()
 		status = {"0": "Draft", "1": "Submitted", "2": "Cancelled"}[cstr(self.docstatus or 0)]
 
 		if self.docstatus == 1:
-			if not self.completed_orders:
+			pending_orders = self.total_orders - self.completed_orders
+			if pending_orders == self.total_orders:
 				status = "Pending"
-			elif self.completed_orders < self.total_orders:
-				status = "In Process"
-			else:
+			elif pending_orders == 0:
 				status = "Completed"
+			else:
+				status = "In Process"
 
-		self.db_set("status", status)
+		self.status = status
+		if update and self.name and not self.is_new():
+			frappe.db.set_value(
+				self.doctype,
+				self.name,
+				{
+					"status": self.status,
+					"total_orders": self.total_orders,
+					"completed_orders": self.completed_orders,
+				},
+				update_modified=False,
+			)
+
+	def get_pending_order_entries(self):
+		pending_orders = []
+		for entry in self.medication_orders:
+			if self.get_order_entry_status(entry) != "Pending":
+				continue
+
+			pending_orders.append(
+				{
+					"name": entry.name,
+					"drug": entry.drug,
+					"drug_name": entry.drug_name,
+					"dosage": entry.dosage,
+					"dosage_form": entry.dosage_form,
+					"date": entry.date,
+					"time": entry.time,
+					"instructions": entry.instructions,
+				}
+			)
+
+		return pending_orders
+
+	@frappe.whitelist()
+	def get_pending_order_entries_for_stop(self):
+		return self.get_pending_order_entries()
+
+	@frappe.whitelist()
+	def stop_pending_order_entries(self, reason, order_entry_names=None):
+		if self.docstatus != 1:
+			frappe.throw(_("Only submitted Inpatient Medication Orders can be stopped."))
+
+		reason = (reason or "").strip()
+		if not reason:
+			frappe.throw(_("Reason is mandatory to stop pending medication orders."))
+
+		pending_entry_names = {entry.get("name") for entry in self.get_pending_order_entries()}
+		if not pending_entry_names:
+			frappe.throw(_("No pending medication orders found to stop."))
+
+		order_entry_names = frappe.parse_json(order_entry_names) if order_entry_names else []
+		selected_entry_names = [entry_name for entry_name in order_entry_names if entry_name in pending_entry_names]
+		if not selected_entry_names:
+			frappe.throw(_("Please select at least one pending medication order to stop."))
+
+		self.remove_rows_from_draft_ipme(selected_entry_names)
+
+		for entry_name in selected_entry_names:
+			frappe.db.set_value(
+				"Inpatient Medication Order Entry",
+				entry_name,
+				{"status": "Stopped", "stop_reason": reason},
+				update_modified=False,
+			)
+
+		self.reload()
+		self.set_status(update=True)
+
+	def get_ipme_map_for_rows(self, order_entry_names):
+		entry_refs = frappe.get_all(
+			"Inpatient Medication Entry Detail",
+			filters={"against_imoe": ("in", order_entry_names)},
+			fields=["parent", "against_imoe"],
+		)
+
+		ipme_map = {}
+		for ref in entry_refs:
+			ipme_map.setdefault(ref.parent, set()).add(ref.against_imoe)
+
+		return ipme_map
+
+
+	def remove_rows_from_draft_ipme(self, order_entry_names):
+		ipme_map = self.get_ipme_map_for_rows(order_entry_names)
+
+		for ipme_name, linked_order_entries in ipme_map.items():
+			ipme = frappe.get_doc("Inpatient Medication Entry", ipme_name)
+
+			if ipme.docstatus == 1:
+				frappe.throw(
+					_(
+						"Some selected medication rows are already administered in submitted Inpatient Medication Entry {0}. Please refresh the document and try again."
+					).format(frappe.bold(ipme.name))
+				)
+
+			if ipme.docstatus == 2:
+				continue
+
+			remaining_rows = [
+				row for row in ipme.medication_orders if row.against_imoe not in linked_order_entries
+			]
+
+			if len(remaining_rows) == len(ipme.medication_orders):
+				continue
+
+			ipme.set("medication_orders", remaining_rows)
+			if remaining_rows:
+				ipme.save(ignore_permissions=True)
+			else:
+				frappe.delete_doc("Inpatient Medication Entry", ipme.name, ignore_permissions=True)
 
 	@frappe.whitelist()
 	def add_order_entries(self, order):
@@ -80,6 +207,7 @@ class InpatientMedicationOrder(Document):
 					entry.dosage_form = order.get("dosage_form")
 					entry.date = date
 					entry.time = dose.strength_time
+					entry.status = "Pending"
 			self.end_date = dates[-1]
 		return
 
@@ -90,3 +218,4 @@ class InpatientMedicationOrder(Document):
 			return
 		for drug in patient_encounter.drug_prescription:
 			self.add_order_entries(drug)
+

--- a/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
@@ -2,8 +2,9 @@
 # For license information, please see license.txt
 
 
-import frappe
 from typing import Any
+
+import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cstr

--- a/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.py
@@ -214,7 +214,7 @@ class InpatientMedicationOrder(Document):
 				frappe.delete_doc("Inpatient Medication Entry", ipme.name, ignore_permissions=True)
 
 	@frappe.whitelist()
-	def add_order_entries(self, order: dict[str, Any]):
+	def add_order_entries(self, order: dict[str, Any] | Document):
 		if order.get("drug_code"):
 			dosage = frappe.get_doc("Prescription Dosage", order.get("dosage"))
 			dates = get_prescription_dates(order.get("period"), self.start_date)

--- a/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
@@ -41,6 +41,7 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 		# 3 dosages per day for 2 days
 		self.assertEqual(len(ipmo.medication_orders), 6)
 		self.assertEqual(ipmo.medication_orders[0].date, add_days(getdate(), -1))
+		self.assertEqual(ipmo.medication_orders[0].status, "Pending")
 
 		prescription_dosage = frappe.get_doc("Prescription Dosage", "1-1-1")
 		for i in range(len(prescription_dosage.dosage_strength)):
@@ -78,6 +79,7 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 		ipme.submit()
 		ipmo.reload()
 		self.assertEqual(ipmo.status, "In Process")
+		self.assertEqual(ipmo.medication_orders[0].status, "Completed")
 
 		filters = frappe._dict(from_date=getdate(), to_date=getdate(), from_time="", to_time="")
 		ipme = create_ipme(filters)
@@ -100,6 +102,84 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 		self.assertTrue(second_ipmo.name)
 		self.assertEqual(second_ipmo.docstatus, 0)
 		self.assertFalse(second_ipmo.patient_encounter)
+		
+	def test_parent_status_is_in_process_when_pending_and_stopped_rows_exist(self):
+		ipmo = create_ipmo(self.patient)
+		ipmo.submit()
+		frappe.db.set_value(
+			"Inpatient Medication Order Entry",
+			ipmo.medication_orders[0].name,
+			{"status": "Stopped", "stop_reason": "Doctor changed treatment"},
+			update_modified=False,
+		)
+		ipmo.reload()
+		ipmo.set_status(update=True)
+		ipmo.reload()
+
+		self.assertEqual(ipmo.status, "In Process")
+
+	def test_stop_pending_orders_updates_rows_and_removes_draft_ipme(self):
+		ipmo = create_ipmo(self.patient)
+		ipmo.submit()
+
+		filters = frappe._dict(
+			from_date=add_days(getdate(), -1), to_date=add_days(getdate(), -1), from_time="", to_time=""
+		)
+		ipme = create_ipme(filters)
+		ipme.submit()
+
+		draft_filters = frappe._dict(from_date=getdate(), to_date=getdate(), from_time="", to_time="")
+		draft_ipme = create_ipme(draft_filters)
+		draft_ipme.insert()
+
+		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == getdate()]
+		ipmo.reload()
+		ipmo.stop_pending_order_entries(
+			"Doctor instructed to stop remaining medication", selected_entries
+		)
+		ipmo.reload()
+
+		self.assertEqual(ipmo.status, "Completed")
+		self.assertFalse(frappe.db.exists("Inpatient Medication Entry", draft_ipme.name))
+
+		for entry in ipmo.medication_orders:
+			if entry.date == getdate():
+				self.assertEqual(entry.status, "Stopped")
+				self.assertEqual(entry.stop_reason, "Doctor instructed to stop remaining medication")
+			else:
+				self.assertEqual(entry.status, "Completed")
+
+	def test_stop_pending_orders_only_updates_selected_rows(self):
+		ipmo = create_ipmo(self.patient)
+		ipmo.submit()
+		selected_entry = ipmo.medication_orders[0].name
+
+		ipmo.stop_pending_order_entries("Stop only first slot", [selected_entry])
+		ipmo.reload()
+
+		self.assertEqual(ipmo.status, "In Process")
+		self.assertEqual(ipmo.medication_orders[0].status, "Stopped")
+		self.assertEqual(ipmo.medication_orders[0].stop_reason, "Stop only first slot")
+		self.assertEqual(ipmo.medication_orders[1].status, "Pending")
+
+	def test_stop_pending_orders_throws_friendly_error_for_submitted_ipme(self):
+		ipmo = create_ipmo(self.patient)
+		ipmo.submit()
+
+		filters = frappe._dict(
+			from_date=add_days(getdate(), -1), to_date=add_days(getdate(), -1), from_time="", to_time=""
+		)
+		ipme = create_ipme(filters)
+		ipme.submit()
+
+		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == add_days(getdate(), -1)]
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Please refresh the document and try again",
+			lambda: ipmo.stop_pending_order_entries("Stop submitted rows", selected_entries),
+		)
+
 
 	def tearDown(self):
 		if frappe.db.get_value("Patient", self.patient, "inpatient_record"):
@@ -174,3 +254,4 @@ def create_ipme(filters, update_stock=0):
 	ipme = ipme.get_medication_orders()
 
 	return ipme
+

--- a/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
@@ -176,8 +176,8 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 
 		self.assertRaisesRegex(
 			frappe.ValidationError,
-			"Please refresh the document and try again",
-			lambda: ipmo.stop_pending_order_entries("Stop submitted rows", selected_entries),
+			"already administered in submitted Inpatient Medication Entry",
+			lambda: ipmo.remove_rows_from_draft_ipme(selected_entries),
 		)
 
 	def test_stop_pending_orders_throws_refresh_error_if_selected_rows_changed(self):

--- a/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
@@ -102,7 +102,7 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 		self.assertTrue(second_ipmo.name)
 		self.assertEqual(second_ipmo.docstatus, 0)
 		self.assertFalse(second_ipmo.patient_encounter)
-		
+
 	def test_parent_status_is_in_process_when_pending_and_stopped_rows_exist(self):
 		ipmo = create_ipmo(self.patient)
 		ipmo.submit()

--- a/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
@@ -118,7 +118,7 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 
 		self.assertEqual(ipmo.status, "In Process")
 
-	def test_stop_pending_orders_updates_rows_and_removes_draft_ipme(self):
+	def test_stop_pending_orders_updates_rows_and_keeps_draft_ipme(self):
 		ipmo = create_ipmo(self.patient)
 		ipmo.submit()
 
@@ -131,14 +131,15 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 		draft_filters = frappe._dict(from_date=getdate(), to_date=getdate(), from_time="", to_time="")
 		draft_ipme = create_ipme(draft_filters)
 		draft_ipme.insert()
-
+		draft_row_count = len(draft_ipme.medication_orders)
 		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == getdate()]
 		ipmo.reload()
 		ipmo.stop_pending_order_entries("Doctor instructed to stop remaining medication", selected_entries)
 		ipmo.reload()
-
+		draft_ipme.reload()
 		self.assertEqual(ipmo.status, "Completed")
-		self.assertFalse(frappe.db.exists("Inpatient Medication Entry", draft_ipme.name))
+		self.assertTrue(frappe.db.exists("Inpatient Medication Entry", draft_ipme.name))
+		self.assertEqual(len(draft_ipme.medication_orders), draft_row_count)
 
 		for entry in ipmo.medication_orders:
 			if entry.date == getdate():
@@ -159,26 +160,6 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 		self.assertEqual(ipmo.medication_orders[0].status, "Stopped")
 		self.assertEqual(ipmo.medication_orders[0].stop_reason, "Stop only first slot")
 		self.assertEqual(ipmo.medication_orders[1].status, "Pending")
-
-	def test_stop_pending_orders_throws_friendly_error_for_submitted_ipme(self):
-		ipmo = create_ipmo(self.patient)
-		ipmo.submit()
-
-		filters = frappe._dict(
-			from_date=add_days(getdate(), -1), to_date=add_days(getdate(), -1), from_time="", to_time=""
-		)
-		ipme = create_ipme(filters)
-		ipme.submit()
-
-		selected_entries = [
-			entry.name for entry in ipmo.medication_orders if entry.date == add_days(getdate(), -1)
-		]
-
-		self.assertRaisesRegex(
-			frappe.ValidationError,
-			"already administered in submitted Inpatient Medication Entry",
-			lambda: ipmo.remove_rows_from_draft_ipme(selected_entries),
-		)
 
 	def test_stop_pending_orders_throws_refresh_error_if_selected_rows_changed(self):
 		ipmo = create_ipmo(self.patient)

--- a/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
+++ b/healthcare/healthcare/doctype/inpatient_medication_order/test_inpatient_medication_order.py
@@ -134,9 +134,7 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 
 		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == getdate()]
 		ipmo.reload()
-		ipmo.stop_pending_order_entries(
-			"Doctor instructed to stop remaining medication", selected_entries
-		)
+		ipmo.stop_pending_order_entries("Doctor instructed to stop remaining medication", selected_entries)
 		ipmo.reload()
 
 		self.assertEqual(ipmo.status, "Completed")
@@ -172,7 +170,9 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 		ipme = create_ipme(filters)
 		ipme.submit()
 
-		selected_entries = [entry.name for entry in ipmo.medication_orders if entry.date == add_days(getdate(), -1)]
+		selected_entries = [
+			entry.name for entry in ipmo.medication_orders if entry.date == add_days(getdate(), -1)
+		]
 
 		self.assertRaisesRegex(
 			frappe.ValidationError,
@@ -180,6 +180,24 @@ class TestInpatientMedicationOrder(HealthcareTestSuite):
 			lambda: ipmo.stop_pending_order_entries("Stop submitted rows", selected_entries),
 		)
 
+	def test_stop_pending_orders_throws_refresh_error_if_selected_rows_changed(self):
+		ipmo = create_ipmo(self.patient)
+		ipmo.submit()
+		selected_entry = ipmo.medication_orders[0].name
+
+		frappe.db.set_value(
+			"Inpatient Medication Order Entry",
+			selected_entry,
+			"status",
+			"Completed",
+			update_modified=False,
+		)
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Some selected medication rows are no longer pending",
+			lambda: ipmo.stop_pending_order_entries("Stop stale row", [selected_entry]),
+		)
 
 	def tearDown(self):
 		if frappe.db.get_value("Patient", self.patient, "inpatient_record"):
@@ -254,4 +272,3 @@ def create_ipme(filters, update_stock=0):
 	ipme = ipme.get_medication_orders()
 
 	return ipme
-

--- a/healthcare/healthcare/doctype/inpatient_medication_order_entry/inpatient_medication_order_entry.json
+++ b/healthcare/healthcare/doctype/inpatient_medication_order_entry/inpatient_medication_order_entry.json
@@ -13,6 +13,8 @@
   "column_break_4",
   "date",
   "time",
+  "status",
+  "stop_reason",
   "is_completed"
  ],
  "fields": [
@@ -63,6 +65,23 @@
    "in_list_view": 1,
    "label": "Time",
    "reqd": 1
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "no_copy": 1,
+   "options": "Pending\nCompleted\nStopped",
+   "read_only": 1
+  },
+  {
+   "fieldname": "stop_reason",
+   "fieldtype": "Small Text",
+   "label": "Stop Reason",
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "default": "0",


### PR DESCRIPTION
Problem

Currently, Inpatient Medication Order (IPMO) does not allow users to stop only the remaining pending medication doses after some doses have already been administered. Stopping the entire medication order is not suitable when a doctor changes the treatment plan midway through the course.

Scenario

A doctor prescribes medication for 2 days, with 3 doses per day.

1. Nursing staff administer all doses for Day 1.
2. The doctor later changes the treatment plan and decides to discontinue the remaining medication.
3. The system should allow staff to stop only the pending Day 2 doses without affecting the already administered doses.

Solution

This PR introduces a Stop Medication Order action that allows users to stop selected pending medication rows while preserving completed medication history.

Changes

1. Stop Medication Order Action

- Added a Stop Medication Order button in Inpatient Medication Order (IPMO).
- Available for submitted medication orders.

2. Child Row Enhancements

Added new fields to Inpatient Medication Order Entry:
- `status`
- `stop_reason`

Supported child row statuses:
- Pending
- Completed
- Stopped

3. Stop Pending Medication Rows

- Displays only Pending medication rows in the stop dialog.
- Allows users to select one or more pending rows.
- Requires a mandatory stop reason before proceeding.
- Selected rows are updated to Stopped.

4. Parent Status Recalculation

Parent IPMO status is automatically recalculated based on child row statuses.

Child Row Status
- Pending
- Completed
- Stopped

Parent IPMO Status
- Pending – All child rows are Pending.
- In Process – Mix of Pending and Completed/Stopped rows.
- Completed – No Pending rows remain (including when all remaining pending rows are stopped).

5. Prevent Future Administration

- Stopped medication rows are excluded from future Inpatient Medication Entry (IPME) creation.
- Completed/administered rows remain unchanged.

6. Draft IPME Handling

Removed automatic deletion of linked draft IPME rows from the IPMO stop flow.

Instead:
- If a draft IPME contains stopped medication rows, the system displays a `frappe.confirm` dialog.
- If the user confirms:
  - Stopped rows are removed from the draft IPME.
  - Row numbering is reorganized.
- If the user declines:
  - Server-side validation prevents saving or submitting the draft until the stopped rows are removed.

7. Stale Row Validation

Added validation to handle concurrent updates.

If any selected medication rows are no longer in the Pending state, the stop operation is blocked and the user is prompted to refresh the document.

Feature Flow

1. Create an Inpatient Medication Order (IPMO).
2. Medication schedule rows are generated with Pending status.
3. Nursing staff administer medication through IPME.
4. Submitted IPME updates administered rows to Completed.
5. Doctor changes the treatment plan.
6. User opens the submitted IPMO.
7. Clicks Stop Medication Order.
8. System displays only pending medication rows.
9. User selects the rows to stop and enters a mandatory reason.
10. Selected rows are marked as Stopped.
11. Parent IPMO status is recalculated.
12. If no pending rows remain, the parent IPMO becomes Completed.
13. Stopped rows are excluded from future IPME generation.
14. If a draft IPME already contains stopped rows:
    - User is prompted to remove them.
    - Confirming removes the rows and reorganizes serial numbering.
    - Otherwise, save/submit is blocked until those rows are cleared.
15. Previously administered (Completed) rows remain unchanged.

no-docs