### PR TITLE
fix(insurance-claim): remove duplicate section/column-break field definitions

### DIFF
--- a/healthcare/healthcare/doctype/insurance_claim/insurance_claim.json
+++ b/healthcare/healthcare/doctype/insurance_claim/insurance_claim.json
@@ -257,15 +257,6 @@
    "reqd": 1
   },
   {
-   "fieldname": "mode_of_payment_section",
-   "fieldtype": "Section Break",
-   "label": "Mode of Payment"
-  },
-  {
-   "fieldname": "column_break_133",
-   "fieldtype": "Column Break"
-  },
-  {
    "fetch_from": "patient.inpatient_record",
    "fieldname": "inpatient_record",
    "fieldtype": "Link",


### PR DESCRIPTION
### Problem

Installing/migrating the `healthcare` app on **frappe `develop` (Python 3.14)** fails:

```
frappe.core.doctype.doctype.doctype.UniqueFieldnameError:
Insurance Claim: Fieldname mode_of_payment_section appears multiple times
```

frappe `develop` validates doctype JSON more strictly than older versions and rejects duplicate fieldnames (older frappe silently kept the last one).

### Cause

In `healthcare/healthcare/doctype/insurance_claim/insurance_claim.json`, the `fields` array contained **two identical definitions** of both `mode_of_payment_section` (Section Break) and `column_break_133` (Column Break) — a duplicated section-break block — while `field_order` references each only once. Looks like an accidental paste during a merge.

### Fix

Remove the duplicate field objects so each fieldname appears exactly once, matching `field_order`. `field_order` is unchanged; the layout is identical. Net result: 35 unique fields, valid JSON.

### Reproduce

Install `healthcare` on a frappe `develop` bench → the site install/migrate aborts with the `UniqueFieldnameError` above.
