### PR TITLE
fix(ipme):- missing admitted-inpatient patient filters in Inpatient Medication Entry

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.js
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.js
@@ -91,4 +91,3 @@ frappe.ui.form.on("Inpatient Medication Entry", {
 		});
 	},
 });
-

--- a/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.js
+++ b/healthcare/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.js
@@ -7,6 +7,24 @@ frappe.ui.form.on("Inpatient Medication Entry", {
 		frm.ignore_doctypes_on_cancel_all = ["Stock Entry"];
 		frm.fields_dict["medication_orders"].grid.wrapper.find(".grid-add-row").hide();
 
+		frm.set_query("patient", () => {
+			return {
+				filters: {
+					inpatient_record: ["!=", ""],
+					inpatient_status: "Admitted",
+				},
+			};
+		});
+
+		frm.set_query("patient", "medication_orders", () => {
+			return {
+				filters: {
+					inpatient_record: ["!=", ""],
+					inpatient_status: "Admitted",
+				},
+			};
+		});
+
 		frm.set_query("item_code", () => {
 			return {
 				filters: {
@@ -73,3 +91,4 @@ frappe.ui.form.on("Inpatient Medication Entry", {
 		});
 	},
 });
+


### PR DESCRIPTION
Issue Description:-
Inpatient Medication Order (IPMO) filters the Patient field to only show patients with a non-empty Inpatient Record and Inpatient Status = Admitted. Inpatient Medication Entry (IPME) did not apply the same restriction, either on the main form Patient field or on the Patient field inside the medication orders table. Because of that mismatch, IPME allowed selecting patients outside the intended admitted inpatient scope.

Fix Applied
Added the same patient query filter used in IPMO to IPME also.

The fix applies to:

- IPME form-level patient field
- IPME child table patient field in medication_orders

Applied filters:
inpatient_record != ""
inpatient_status = "Admitted"