### PR TITLE
feat(diagnostics): add emergency record field to sample collection and diagnostic report

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -11,6 +11,7 @@
   "patient",
   "patient_name",
   "inpatient_record",
+  "emergency_record",
   "gender",
   "age",
   "practitioner",
@@ -53,6 +54,15 @@
    "fieldtype": "Link",
    "label": "Inpatient Record",
    "options": "Inpatient Record",
+   "read_only": 1,
+   "fetch_if_empty": 1
+  },
+  {
+   "fetch_from": "patient.emergency_record",
+   "fieldname": "emergency_record",
+   "fieldtype": "Link",
+   "label": "Emergency Record",
+   "options": "Emergency Record",
    "read_only": 1,
    "fetch_if_empty": 1
   },
@@ -214,3 +224,4 @@
  "title_field": "title",
  "track_changes": 1
 }
+

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.json
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.json
@@ -14,6 +14,7 @@
   "patient_name",
   "patient_age",
   "patient_sex",
+  "emergency_record",
   "appointment",
   "referring_practitioner",
   "column_break_4",
@@ -50,6 +51,16 @@
    "hide_seconds": 1,
    "label": "Inpatient Record",
    "options": "Inpatient Record",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "patient.emergency_record",
+   "fieldname": "emergency_record",
+   "fieldtype": "Link",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Emergency Record",
+   "options": "Emergency Record",
    "read_only": 1
   },
   {
@@ -356,3 +367,4 @@
  "track_changes": 1,
  "track_seen": 1
 }
+


### PR DESCRIPTION
When a patient is registered to ER, emergency_record is already visible in Patient Encounter and Service Request, but it was missing in Sample Collection and Diagnostic Report.

This caused ER-linked context to be inconsistent across related healthcare documents.

Expected behavior:
emergency_record should also be available in Sample Collection and Diagnostic Report, similar to how related patient-linked fields are shown there.

Fix Applied / Changes Applied:-

- Added emergency_record to Diagnostic Report field metadata.
- Added emergency_record to Sample Collection field metadata.
- Set both fields to fetch from patient.emergency_record.

Note:-
Matched existing DocType behavior:
- Diagnostic Report uses fetch_if_empty, same as its inpatient_record field.
- Sample Collection does not use fetch_if_empty, matching its current inpatient_record setup.

no-docs