### PR TITLE
fix: remove extra blank lines from sample collection and diagnostic report json files

### DIFF
--- a/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
+++ b/healthcare/healthcare/doctype/diagnostic_report/diagnostic_report.json
@@ -224,4 +224,3 @@
  "title_field": "title",
  "track_changes": 1
 }
-

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.json
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.json
@@ -367,4 +367,3 @@
  "track_changes": 1,
  "track_seen": 1
 }
-


### PR DESCRIPTION
Remove extra blank lines from sample_collection.json and diagnostic_report.json files