### PR TITLE
fix(healthcare): allow return sales invoices for already invoiced appointment refs

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1223,9 +1223,7 @@ def set_invoiced(item, method, ref_invoice=None):
 
 
 def validate_invoiced_on_submit(item):
-	if item.parenttype == "Sales Invoice" and frappe.db.get_value(
-		item.parenttype, item.parent, "is_return"
-	):
+	if item.parenttype == "Sales Invoice" and frappe.db.get_value(item.parenttype, item.parent, "is_return"):
 		return
 
 	is_invoiced = False
@@ -1922,4 +1920,3 @@ def add_node():
 		args.parent_healthcare_service_unit = None
 
 	frappe.get_doc(args).insert()
-

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1223,6 +1223,11 @@ def set_invoiced(item, method, ref_invoice=None):
 
 
 def validate_invoiced_on_submit(item):
+	if item.parenttype == "Sales Invoice" and frappe.db.get_value(
+		item.parenttype, item.parent, "is_return"
+	):
+		return
+
 	is_invoiced = False
 	if (
 		item.reference_dt == "Clinical Procedure"
@@ -1917,3 +1922,4 @@ def add_node():
 		args.parent_healthcare_service_unit = None
 
 	frappe.get_doc(args).insert()
+


### PR DESCRIPTION
Submitting a credit note for a Sales Invoice linked to a Patient Appointment fails during submission with the validation error:
The item referenced by Patient Appointment - HLC-APP-2026-00001 is already invoiced

This happens because Healthcare’s on_submit invoice handling calls validate_invoiced_on_submit() for each referenced item even when the invoice is a return (is_return = 1). For a credit note, the linked appointment was already invoiced by the original Sales Invoice, so the existing duplicate-invoice check incorrectly treats the return invoice as a new invoice and blocks submission.

Changes Applied
In utils.py, added an early return in validate_invoiced_on_submit(item) when:
item.parenttype == "Sales Invoice"
the parent Sales Invoice has is_return = 1

This ensures the “already invoiced” validation is skipped only for return Sales Invoices (credit notes), while normal Sales Invoices continue to use the existing protection.

Fix Summary
Before:
Credit note submission against an already invoiced appointment failed with already invoiced.
After:
Return Sales Invoices bypass that duplicate-invoice validation.
Standard Sales Invoice submission behavior remains unchanged.