### PR TITLE
fix(healthcare): allow credit note submission for invoiced appointment items

### DIFF
--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -134,7 +134,7 @@ def set_service_request_status(service_request, status):
 
 
 @frappe.whitelist()
-def make_clinical_procedure(service_request, appointment=None):
+def make_clinical_procedure(service_request: str, appointment: str | None = None):
 	if not service_request:
 		return
 
@@ -171,7 +171,8 @@ def make_clinical_procedure(service_request, appointment=None):
 	doc.insurance_coverage = service_request.insurance_coverage
 	doc.coverage_status = service_request.coverage_status
 	doc.consume_stock = procedure_template.consume_stock
-	doc.warehouse = frappe.db.get_single_value("Stock Settings", "default_warehouse")
+	if doc.consume_stock and frappe.get_meta("Stock Settings").has_field("default_warehouse"):
+		doc.warehouse = frappe.db.get_single_value("Stock Settings", "default_warehouse")
 
 	if not doc.codification_table and procedure_template.codification_table:
 		for code in procedure_template.codification_table:

--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1034,8 +1034,7 @@ def manage_invoice_submit_cancel(doc, method):
 		for item in doc.items:
 			if item.get("reference_dt") and item.get("reference_dn"):
 				# TODO check
-				# if frappe.get_meta(item.reference_dt).has_field("invoiced"):
-				set_invoiced(item, method, doc.name)
+				set_invoiced(item, method, doc)
 
 				# update Fee validity with Sales Invoice Reference if exists
 				if item.reference_dt == "Patient Appointment":
@@ -1173,10 +1172,16 @@ def post_transfer_journal_entry_and_update_coverage(sales_invoice):
 		coverage.update_invoice_details(item.qty, item.insurance_coverage_amount)
 
 
-def set_invoiced(item, method, ref_invoice=None):
+def set_invoiced(item, method, sales_invoice=None):
+	ref_invoice = sales_invoice.name if sales_invoice else None
+	is_return = bool(sales_invoice and sales_invoice.is_return)
+
 	invoiced = False
 	if method == "on_submit":
-		validate_invoiced_on_submit(item)
+		if not is_return:
+			validate_invoiced_on_submit(item)
+		invoiced = True
+	elif method == "on_cancel" and is_return:
 		invoiced = True
 
 	if item.reference_dt == "Clinical Procedure":
@@ -1195,6 +1200,10 @@ def set_invoiced(item, method, ref_invoice=None):
 		else:
 			dt_from_appointment = "Patient Encounter"
 		manage_doc_for_appointment(dt_from_appointment, item.reference_dn, invoiced)
+		if is_return:
+			if method == "on_submit":
+				return
+			ref_invoice = frappe.db.get_value("Patient Appointment", item.reference_dn, "ref_sales_invoice")
 		frappe.db.set_value("Patient Appointment", item.reference_dn, "ref_sales_invoice", ref_invoice)
 
 	elif item.reference_dt == "Lab Prescription":


### PR DESCRIPTION
Issue Description
Submitting a credit note from a Sales Invoice that contains Patient Appointment items was failing with:
The item referenced by Patient Appointment - HLC-APP-2026-00221 is already invoiced

This happened because manage_invoice_submit_cancel called set_invoiced with only doc.name, and set_invoiced always treated on_submit like a fresh invoice submission. 

During return invoice submit, it re-ran validate_invoiced_on_submit(item), which correctly saw the linked appointment was already invoiced by the original invoice and threw the error. The flow also lacked enough invoice context to distinguish a normal invoice from a return invoice without extra DB work.

Changes Applied:-
- Updated manage_invoice_submit_cancel in utils.py to pass the full Sales Invoice doc into set_invoiced instead of only doc.name.
- Refactored set_invoiced in utils.py to use the invoice doc context directly.
- Added return-invoice handling using sales_invoice.is_return.
- Skipped validate_invoiced_on_submit(item) when the submitted invoice is a return, so credit note submission no longer re-fails on already invoiced appointment references.
- Preserved appointment invoiced state on return cancel by keeping invoiced = True for on_cancel of return invoices.
- Prevented return invoice submit from overwriting Patient Appointment.ref_sales_invoice.
- On return cancel, preserved the existing appointment ref_sales_invoice instead of clearing or replacing it.