### PR TITLE
fix(clinical-procedure): manual Clinical Procedure creation to load template consumables and consume stock

### DIFF
--- a/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
+++ b/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
@@ -294,13 +294,66 @@ frappe.ui.form.on("Clinical Procedure", {
 
 	procedure_template: function (frm) {
 		if (frm.doc.procedure_template) {
+			const selected_template = frm.doc.procedure_template;
+			const request_id = (frm.procedure_template_request_id || 0) + 1;
+			frm.procedure_template_request_id = request_id;
+
+			frappe.db
+				.get_value(
+					"Clinical Procedure Template",
+					selected_template,
+					"consume_stock",
+				)
+				.then(r => {
+					if (
+						!is_active_procedure_template_request(
+							frm,
+							selected_template,
+							request_id,
+						)
+					) {
+						return;
+					}
+
+					const consume_stock = cint(r.message?.consume_stock);
+					frm.set_value("consume_stock", consume_stock);
+
+					if (consume_stock) {
+						frm.events.set_procedure_consumables(
+							frm,
+							selected_template,
+							request_id,
+						);
+						if (!frm.doc.warehouse) {
+							frm.events.set_warehouse(
+								frm,
+								selected_template,
+								request_id,
+							);
+						}
+					} else {
+						frm.clear_table("items");
+						frm.refresh_field("items");
+					}
+				});
+
 			frappe.call({
 				method: "healthcare.healthcare.utils.get_medical_codes",
 				args: {
 					template_dt: "Clinical Procedure Template",
-					template_dn: frm.doc.procedure_template,
+					template_dn: selected_template,
 				},
 				callback: function (r) {
+					if (
+						!is_active_procedure_template_request(
+							frm,
+							selected_template,
+							request_id,
+						)
+					) {
+						return;
+					}
+
 					if (!r.exc && r.message) {
 						frm.doc.codification_table = [];
 						$.each(r.message, function (k, val) {
@@ -321,11 +374,15 @@ frappe.ui.form.on("Clinical Procedure", {
 				},
 			});
 		} else {
+			frm.procedure_template_request_id =
+				(frm.procedure_template_request_id || 0) + 1;
+			frm.set_value("consume_stock", 0);
+			frm.clear_table("items");
+			frm.refresh_field("items");
 			frm.clear_table("codification_table");
 			frm.refresh_field("codification_table");
 		}
 	},
-
 	service_unit: function (frm) {
 		if (frm.doc.service_unit) {
 			frappe.call({
@@ -366,7 +423,11 @@ frappe.ui.form.on("Clinical Procedure", {
 		}
 	},
 
-	set_warehouse: function (frm) {
+	set_warehouse: function (
+		frm,
+		selected_template = frm.doc.procedure_template,
+		request_id = null,
+	) {
 		if (!frm.doc.warehouse) {
 			frappe.call({
 				method: "frappe.client.get_value",
@@ -375,21 +436,47 @@ frappe.ui.form.on("Clinical Procedure", {
 					fieldname: "default_warehouse",
 				},
 				callback: function (data) {
+					if (
+						!is_active_procedure_template_request(
+							frm,
+							selected_template,
+							request_id,
+						) ||
+						frm.doc.warehouse
+					) {
+						return;
+					}
+
 					frm.set_value("warehouse", data.message.default_warehouse);
 				},
 			});
 		}
 	},
+	set_procedure_consumables: function (
+		frm,
+		selected_template = frm.doc.procedure_template,
+		request_id = null,
+	) {
+		frm.clear_table("items");
+		frm.refresh_field("items");
 
-	set_procedure_consumables: function (frm) {
 		frappe.call({
 			method: "healthcare.healthcare.doctype.clinical_procedure.clinical_procedure.get_procedure_consumables",
 			args: {
-				procedure_template: frm.doc.procedure_template,
+				procedure_template: selected_template,
 			},
 			callback: function (data) {
+				if (
+					!is_active_procedure_template_request(
+						frm,
+						selected_template,
+						request_id,
+					)
+				) {
+					return;
+				}
+
 				if (data.message) {
-					frm.doc.items = [];
 					$.each(data.message, function (i, v) {
 						let item = frm.add_child("items");
 						item.item_code = v.item_code;
@@ -403,12 +490,28 @@ frappe.ui.form.on("Clinical Procedure", {
 							v.invoice_separately_as_consumables;
 						item.batch_no = v.batch_no;
 					});
-					refresh_field("items");
+					frm.refresh_field("items");
+				} else {
+					frm.clear_table("items");
+					frm.refresh_field("items");
 				}
+			},
+			error: function () {
+				if (
+					!is_active_procedure_template_request(
+						frm,
+						selected_template,
+						request_id,
+					)
+				) {
+					return;
+				}
+
+				frm.clear_table("items");
+				frm.refresh_field("items");
 			},
 		});
 	},
-
 	set_medical_codes: function (frm) {
 		frappe.call({
 			method: "healthcare.healthcare.utils.get_medical_codes",
@@ -496,6 +599,21 @@ let calculate_age = function (birth) {
 	return `${years} ${__("Years(s)")} ${age.getMonth()} ${__(
 		"Month(s)",
 	)} ${age.getDate()} ${__("Day(s)")}`;
+};
+
+let is_active_procedure_template_request = function (
+	frm,
+	selected_template,
+	request_id,
+) {
+	if (!selected_template) {
+		return false;
+	}
+
+	return (
+		frm.doc.procedure_template === selected_template &&
+		(request_id == null || frm.procedure_template_request_id === request_id)
+	);
 };
 
 let get_procedure_prescribed = function (frm) {


### PR DESCRIPTION
Issue Description:-
When a Clinical Procedure is created from the encounter flow, the system creates a Service Request, and then the Clinical Procedure inherits the template’s stock-consumption behavior correctly:
        - consume_stock gets checked if the template allows stock consumption.
        - consumable items from the Clinical Procedure Template are copied into the procedure.

But when a Clinical Procedure is created manually and the same template is selected:
   1.consume_stock was not being set from the template
   2. consumable items were not being loaded automatically

This created inconsistent behavior between the encounter-driven flow and the manual flow for the same template configuration.

Fix Applied:-
In clinical_procedure.js , the procedure_template form handler was updated so that on manual template selection it now:
        - fetches consume_stock from the selected Clinical Procedure Template
        - sets the consume_stock checkbox on the Clinical Procedure form
        - loads template consumables into the items table when stock consumption is enabled
        - sets a default warehouse if needed
        - clears existing consumables when the selected template does not allow stock consumption
        - clears consume_stock and consumables when the template is removed

Why This Change Was Needed:-
The backend encounter/service-request path already handled this correctly, but the manual UI path only fetched medical codes and skipped consumable/stock behavior. The fix makes both creation paths behave consistently and prevents users from having to add consumables manually for templates that are already configured to supply them.

Updated Flow After the Fix:-

1. User creates a Clinical Procedure manually.
2. User selects a Clinical Procedure Template.
3. System fetches template medical codes as before.
4. System also checks whether the template has consume_stock enabled.
5.If enabled:

- consume_stock is checked on the form
- template consumables are loaded into the items table
- warehouse is set if missing

6.If not enabled:
    - consume_stock remains unchecked
    - consumable rows are cleared
7.If the template is cleared:
    - consume_stock is reset
    - consumables are cleared
    
Closes issue #1138 