### PR TITLE
fix(clinical-procedure): sync template consumables and consume stock on manual clinical procedure creation

### DIFF
--- a/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
+++ b/healthcare/healthcare/doctype/clinical_procedure/clinical_procedure.js
@@ -1,6 +1,10 @@
 // Copyright (c) 2017, ESS LLP and contributors
 // For license information, please see license.txt
 
+const show_consumables_message = (message, indicator = "orange") => {
+	frappe.show_alert({ message, indicator }, 7);
+};
+
 frappe.ui.form.on("Clinical Procedure", {
 	setup: function (frm) {
 		frm.set_query("batch_no", "items", function (doc, cdt, cdn) {
@@ -293,7 +297,59 @@ frappe.ui.form.on("Clinical Procedure", {
 	},
 
 	procedure_template: function (frm) {
+		const clear_stock_state = () => {
+			frm.set_value("consume_stock", 0);
+			frm.clear_table("items");
+			frm.refresh_field("items");
+		};
+
 		if (frm.doc.procedure_template) {
+			frappe.db
+				.get_value(
+					"Clinical Procedure Template",
+					frm.doc.procedure_template,
+					"consume_stock",
+				)
+				.then(({ message }) => {
+					if (!message) {
+						clear_stock_state();
+						show_consumables_message(
+							__(
+								"Consumables could not be loaded because the selected Clinical Procedure Template's stock settings could not be fetched.",
+							),
+						);
+						return;
+					}
+
+					const consume_stock = cint(message.consume_stock);
+
+					return frm.set_value("consume_stock", consume_stock).then(() => {
+						if (frm.doc.service_unit) {
+							frm.trigger("service_unit");
+						} else if (consume_stock && !frm.doc.warehouse) {
+							frm.trigger("set_warehouse");
+						}
+
+						if (consume_stock) {
+							frm.trigger("set_procedure_consumables");
+						} else {
+							show_consumables_message(
+								__(
+									"Consumables were not loaded because the selected Clinical Procedure Template does not consume stock.",
+								),
+							);
+						}
+					});
+				})
+				.catch(() => {
+					clear_stock_state();
+					show_consumables_message(
+						__(
+							"Consumables could not be loaded because the selected Clinical Procedure Template's stock settings could not be fetched.",
+						),
+					);
+				});
+
 			frappe.call({
 				method: "healthcare.healthcare.utils.get_medical_codes",
 				args: {
@@ -321,11 +377,11 @@ frappe.ui.form.on("Clinical Procedure", {
 				},
 			});
 		} else {
+			clear_stock_state();
 			frm.clear_table("codification_table");
 			frm.refresh_field("codification_table");
 		}
 	},
-
 	service_unit: function (frm) {
 		if (frm.doc.service_unit) {
 			frappe.call({
@@ -378,29 +434,51 @@ frappe.ui.form.on("Clinical Procedure", {
 	},
 
 	set_procedure_consumables: function (frm) {
+		const clear_consumables = () => {
+			frm.clear_table("items");
+			frm.refresh_field("items");
+		};
+		const requested_template = frm.doc.procedure_template;
+
 		frappe.call({
 			method: "healthcare.healthcare.doctype.clinical_procedure.clinical_procedure.get_procedure_consumables",
 			args: {
-				procedure_template: frm.doc.procedure_template,
+				procedure_template: requested_template,
 			},
 			callback: function (data) {
-				if (data.message) {
-					frm.doc.items = [];
-					$.each(data.message, function (i, v) {
-						let item = frm.add_child("items");
-						item.item_code = v.item_code;
-						item.item_name = v.item_name;
-						item.uom = v.uom;
-						item.stock_uom = v.stock_uom;
-						item.qty = flt(v.qty);
-						item.transfer_qty = v.transfer_qty;
-						item.conversion_factor = v.conversion_factor;
-						item.invoice_separately_as_consumables =
-							v.invoice_separately_as_consumables;
-						item.batch_no = v.batch_no;
-					});
-					refresh_field("items");
+				clear_consumables();
+				if (!data.message || !data.message.length) {
+					show_consumables_message(
+						__(
+							"The selected Clinical Procedure Template does not have any consumables configured.",
+						),
+					);
+					return;
 				}
+
+				$.each(data.message, function (i, v) {
+					let item = frm.add_child("items");
+					item.item_code = v.item_code;
+					item.item_name = v.item_name;
+					item.uom = v.uom;
+					item.stock_uom = v.stock_uom;
+					item.qty = flt(v.qty);
+					item.transfer_qty = v.transfer_qty;
+					item.conversion_factor = v.conversion_factor;
+					item.invoice_separately_as_consumables =
+						v.invoice_separately_as_consumables;
+					item.batch_no = v.batch_no;
+				});
+				frm.refresh_field("items");
+			},
+			error: function () {
+				clear_consumables();
+				show_consumables_message(
+					__(
+						"Consumables could not be loaded for the selected Clinical Procedure Template. Please try again.",
+					),
+					"red",
+				);
 			},
 		});
 	},


### PR DESCRIPTION
Issue Description:-
When a Clinical Procedure is created from an Encounter or Service Request using a Clinical Procedure Template, the template’s consumables and consume_stock setting are populated correctly.

However, when a user creates a Clinical Procedure manually and selects the same template on the form, the consumables table is not populated and consume_stock is not synced from the template even if its exist. This creates inconsistent behavior across creation flows and can lead to missed stock consumption setup for manual procedures.

Fix Applied
Updated the manual Clinical Procedure form flow in clinical_procedure.js so that when procedure_template is selected:
        - consume_stock is fetched from the selected Clinical Procedure Template
        - warehouse defaulting is triggered when needed
        - template consumables are loaded into the items table
        - clearing the template resets consume_stock and clears items

Closes issue https://github.com/earthians/marley/issues/1138