### PR TITLE
fix(inpatient): inpatient discharge flow so service unit becomes vacant only on final discharge not on discharge scheduled

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -394,13 +394,13 @@ def create_inpatient_record(admission_order):
 
 
 @frappe.whitelist()
-def schedule_discharge(discharge_order):
+def schedule_discharge(discharge_order: str):
 	discharge_order = json.loads(discharge_order)
 	inpatient_record_id = frappe.db.get_value("Patient", discharge_order["patient"], "inpatient_record")
 
 	if inpatient_record_id:
 		inpatient_record = frappe.get_doc("Inpatient Record", inpatient_record_id)
-		check_out_inpatient(inpatient_record)
+
 		set_details_from_ip_order(inpatient_record, discharge_order)
 		inpatient_record.status = "Discharge Scheduled"
 		inpatient_record.save(ignore_permissions=True)
@@ -454,6 +454,7 @@ def discharge_patient(inpatient_record):
 
 	validate_incomplete_service_requests(inpatient_record)
 
+	check_out_inpatient(inpatient_record)
 	inpatient_record.discharge_datetime = now_datetime()
 	inpatient_record.status = "Discharged"
 

--- a/healthcare/healthcare/doctype/inpatient_record/test_inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/test_inpatient_record.py
@@ -37,8 +37,9 @@ class TestInpatientRecord(HealthcareTestSuite):
 
 		# Discharge
 		schedule_discharge(frappe.as_json({"patient": patient}))
+		self.assertEqual("Discharge Scheduled", frappe.db.get_value("Patient", patient, "inpatient_status"))
 		self.assertEqual(
-			"Vacant", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
+			"Occupied", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
 		)
 
 		ip_record1 = frappe.get_doc("Inpatient Record", ip_record.name)
@@ -47,6 +48,9 @@ class TestInpatientRecord(HealthcareTestSuite):
 		mark_invoiced_inpatient_occupancy(ip_record1)
 
 		discharge_patient(ip_record1)
+		self.assertEqual(
+			"Vacant", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
+		)
 
 		self.assertEqual(None, frappe.db.get_value("Patient", patient, "inpatient_record"))
 		self.assertEqual(None, frappe.db.get_value("Patient", patient, "inpatient_status"))
@@ -68,12 +72,15 @@ class TestInpatientRecord(HealthcareTestSuite):
 		# Discharge
 		schedule_discharge(frappe.as_json({"patient": patient}))
 		self.assertEqual(
-			"Vacant", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
+			"Occupied", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
 		)
 
 		ip_record = frappe.get_doc("Inpatient Record", ip_record.name)
 		# Should not validate Pending Invoices
 		ip_record.discharge()
+		self.assertEqual(
+			"Vacant", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
+		)
 
 		self.assertEqual(None, frappe.db.get_value("Patient", patient, "inpatient_record"))
 		self.assertEqual(None, frappe.db.get_value("Patient", patient, "inpatient_status"))
@@ -102,12 +109,15 @@ class TestInpatientRecord(HealthcareTestSuite):
 		# Discharge
 		schedule_discharge(frappe.as_json({"patient": patient}))
 		self.assertEqual(
-			"Vacant", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
+			"Occupied", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
 		)
 
 		ip_record = frappe.get_doc("Inpatient Record", ip_record.name)
 		mark_invoiced_inpatient_occupancy(ip_record)
 		discharge_patient(ip_record)
+		self.assertEqual(
+			"Vacant", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
+		)
 		setup_inpatient_settings(key="do_not_bill_inpatient_encounters", value=0)
 
 	def test_validate_overlap_admission(self):


### PR DESCRIPTION
Issue description:-
In the inpatient flow, the Healthcare Service Unit occupancy is being marked as Vacant during Order Discharge:
     Inpatient Record -> Schedule Discharge -> Order Discharge

At that point, the Inpatient Record status is still Discharge Scheduled, so the patient is not yet fully discharged. This causes the bed/service unit to appear available too early, which can lead to incorrect occupancy visibility and possible reassignment before the final discharge is completed.

Expected behavior:
The Healthcare Service Unit should remain Occupied while the Inpatient Record is Discharge Scheduled and should only be set to Vacant when the patient is finally discharged and the record moves to Discharged.

Fix / changes applied:-

- Removed the occupancy checkout call from schedule_discharge().
- Kept the Healthcare Service Unit in Occupied state during Discharge Scheduled.
- Moved the occupancy checkout logic to discharge_patient().
- Ensured the service unit is marked Vacant only when final discharge is completed.
- Updated regression tests to verify:
1. Order Discharge keeps the unit Occupied
2. final discharge changes the unit to Vacant

After-fix flow
- Patient is admitted.
- Healthcare Service Unit is set to Occupied.
- User clicks Schedule Discharge and completes Order Discharge.
- Inpatient Record status becomes Discharge Scheduled.
- Healthcare Service Unit remains Occupied.
- Final discharge is performed.
- Inpatient Record status becomes Discharged.
- Active occupancy row is checked out.
- Healthcare Service Unit is set to Vacant.

Closes issue: #1141 