### PR TITLE
fix(inpatient): allow discharge when pending healthcare services override is enabled in healthcare settings

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -811,7 +811,7 @@ def set_total(self):
 
 
 def validate_incomplete_service_requests(inpatient_record):
-	if not frappe.db.get_single_value(
+	if frappe.db.get_single_value(
 		"Healthcare Settings", "allow_discharge_despite_pending_healthcare_services"
 	):
 		return

--- a/healthcare/healthcare/doctype/inpatient_record/test_inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/test_inpatient_record.py
@@ -3,7 +3,7 @@
 
 
 import frappe
-from frappe.utils import add_to_date, flt, now_datetime, today
+from frappe.utils import add_to_date, flt, now_datetime, nowtime, today
 from frappe.utils.make_random import get_random
 
 from healthcare.healthcare.doctype.inpatient_record.inpatient_record import (
@@ -87,9 +87,88 @@ class TestInpatientRecord(HealthcareTestSuite):
 
 		setup_inpatient_settings(key="allow_discharge_despite_unbilled_services", value=0)
 
+	def test_allow_discharge_despite_pending_healthcare_services(self):
+		frappe.db.sql("""delete from `tabInpatient Record`""")
+		previous_pending_services = frappe.db.get_single_value(
+			"Healthcare Settings", "allow_discharge_despite_pending_healthcare_services"
+		)
+		self.addCleanup(
+			setup_inpatient_settings,
+			key="allow_discharge_despite_pending_healthcare_services",
+			value=previous_pending_services,
+		)
+		setup_inpatient_settings(key="allow_discharge_despite_pending_healthcare_services", value=1)
+		patient = frappe.get_list("Patient", pluck="name")[0]
+		ip_record = create_inpatient(patient)
+		ip_record.expected_length_of_stay = 0
+		ip_record.save(ignore_permissions=True)
+
+		service_unit = get_healthcare_service_unit()
+		admit_patient(ip_record, service_unit, now_datetime())
+		create_pending_service_request(ip_record)
+
+		schedule_discharge(frappe.as_json({"patient": patient}))
+		self.assertEqual(
+			"Occupied", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
+		)
+
+		ip_record = frappe.get_doc("Inpatient Record", ip_record.name)
+		mark_invoiced_inpatient_occupancy(ip_record)
+		ip_record.discharge()
+		self.assertEqual(
+			"Vacant", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
+		)
+		self.assertEqual(None, frappe.db.get_value("Patient", patient, "inpatient_record"))
+		self.assertEqual(None, frappe.db.get_value("Patient", patient, "inpatient_status"))
+
+	def test_disallow_discharge_with_pending_healthcare_services(self):
+		frappe.db.sql("""delete from `tabInpatient Record`""")
+		previous_pending_services = frappe.db.get_single_value(
+			"Healthcare Settings", "allow_discharge_despite_pending_healthcare_services"
+		)
+		self.addCleanup(
+			setup_inpatient_settings,
+			key="allow_discharge_despite_pending_healthcare_services",
+			value=previous_pending_services,
+		)
+		setup_inpatient_settings(key="allow_discharge_despite_pending_healthcare_services", value=0)
+		patient = frappe.get_list("Patient", pluck="name")[0]
+		ip_record = create_inpatient(patient)
+		ip_record.expected_length_of_stay = 0
+		ip_record.save(ignore_permissions=True)
+
+		service_unit = get_healthcare_service_unit()
+		admit_patient(ip_record, service_unit, now_datetime())
+		create_pending_service_request(ip_record)
+
+		schedule_discharge(frappe.as_json({"patient": patient}))
+		ip_record = frappe.get_doc("Inpatient Record", ip_record.name)
+		mark_invoiced_inpatient_occupancy(ip_record)
+		self.assertRaises(frappe.ValidationError, ip_record.discharge)
+		self.assertEqual(
+			"Occupied", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
+		)
+
 	def test_do_not_bill_patient_encounters_for_inpatients(self):
 		frappe.db.sql("""delete from `tabInpatient Record`""")
+		previous_do_not_bill = frappe.db.get_single_value(
+			"Healthcare Settings", "do_not_bill_inpatient_encounters"
+		)
+		previous_pending_services = frappe.db.get_single_value(
+			"Healthcare Settings", "allow_discharge_despite_pending_healthcare_services"
+		)
+		self.addCleanup(
+			setup_inpatient_settings,
+			key="do_not_bill_inpatient_encounters",
+			value=previous_do_not_bill,
+		)
+		self.addCleanup(
+			setup_inpatient_settings,
+			key="allow_discharge_despite_pending_healthcare_services",
+			value=previous_pending_services,
+		)
 		setup_inpatient_settings(key="do_not_bill_inpatient_encounters", value=1)
+		setup_inpatient_settings(key="allow_discharge_despite_pending_healthcare_services", value=1)
 		patient = frappe.get_list("Patient", pluck="name")[0]
 		# Schedule Admission
 		ip_record = create_inpatient(patient)
@@ -118,7 +197,6 @@ class TestInpatientRecord(HealthcareTestSuite):
 		self.assertEqual(
 			"Vacant", frappe.db.get_value("Healthcare Service Unit", service_unit, "occupancy_status")
 		)
-		setup_inpatient_settings(key="do_not_bill_inpatient_encounters", value=0)
 
 	def test_validate_overlap_admission(self):
 		frappe.db.sql("""delete from `tabInpatient Record`""")
@@ -249,6 +327,30 @@ def create_inpatient(patient):
 	inpatient_record.scheduled_date = today()
 	inpatient_record.company = "_Test Company"
 	return inpatient_record
+
+
+def create_pending_service_request(ip_record):
+	patient = frappe.get_doc("Patient", ip_record.patient)
+	service_request = frappe.get_doc(
+		{
+			"doctype": "Service Request",
+			"order_date": today(),
+			"order_time": nowtime(),
+			"company": "_Test Company",
+			"patient": ip_record.patient,
+			"patient_name": patient.patient_name,
+			"patient_gender": patient.sex,
+			"practitioner": frappe.get_list("Healthcare Practitioner", pluck="name")[0],
+			"inpatient_record": ip_record.name,
+			"status": "draft-Request Status",
+			"quantity": 1,
+			"template_dt": "Lab Test Template",
+			"template_dn": "_Test Lab Test - with Sample",
+		}
+	)
+	service_request.insert(ignore_permissions=True, ignore_mandatory=True)
+	service_request.submit()
+	return service_request
 
 
 def get_healthcare_service_unit(unit_name=None):


### PR DESCRIPTION
Issue Description:-
When Healthcare Settings.allow_discharge_despite_pending_healthcare_services was enabled, inpatient discharge was still being blocked if there were submitted Service Request records linked to the inpatient record whose status was not completed.

The problem was in inpatient_record.py : the guard in validate_incomplete_service_requests(inpatient_record) was inverted. Instead of skipping validation when the override setting was enabled, it continued into the pending-service check and threw Incomplete Services.

Fix Applied:-

- In inpatient_record.py , changed the condition so the function returns immediately when         allow_discharge_despite_pending_healthcare_services is enabled.

- Added a new test in test_inpatient_record.py, named test_allow_discharge_despite_pending_healthcare_services and a small helper  to create a pending submitted Service Request linked to the inpatient record.

Flow After Fix
1. Discharge is triggered for an inpatient record.
2. discharge_patient() calls validate_inpatient_invoicing().
3. If allow_discharge_despite_unbilled_services is enabled, invoice blocking is skipped.
4. discharge_patient() then calls validate_incomplete_service_requests().
5. If allow_discharge_despite_pending_healthcare_services is enabled, the function now returns immediately.
6. No validation error is raised for pending submitted Service Request records.
7. Checkout proceeds, occupancy is marked vacant, and the inpatient record is discharged.