### PR TITLE
fix(sample-collection): set status to Pending when no samples are collected

### DIFF
--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -40,10 +40,7 @@ class SampleCollection(Document):
 					if not any((comp["status"] == "Open") for comp in component_observations):
 						obs.status = "Collected"
 
-		if not any((obs.get("status") == "Open") for obs in self.observation_sample_collection):
-			self.status = "Collected"
-		else:
-			self.status = "Partly Collected"
+		self.status = get_collection_status(self.observation_sample_collection)
 
 	# def before_submit(self):
 	# 	if [sample for sample in self.observation_sample_collection if sample.status != "Collected"]:
@@ -228,12 +225,23 @@ def update_child_status(context):
 def update_collection_status(context):
 	if not context.sample_collection:
 		return
-	non_collected = frappe.db.get_all(
+	child_rows = frappe.db.get_all(
 		"Observation Sample Collection",
-		{"parent": context.sample_collection, "status": ["!=", "Collected"]},
+		{"parent": context.sample_collection},
+		["status"],
 	)
-	status = "Partly Collected" if non_collected else "Collected"
+	status = get_collection_status(child_rows)
 	frappe.db.set_value("Sample Collection", context.sample_collection, "status", status)
+
+
+def get_collection_status(child_rows):
+	if not child_rows:
+		return "Pending"
+	if all(row.get("status") == "Collected" for row in child_rows):
+		return "Collected"
+	if all(row.get("status") == "Open" for row in child_rows):
+		return "Pending"
+	return "Partly Collected"
 
 
 def parent_observation(context, obs):

--- a/healthcare/healthcare/doctype/sample_collection/sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/sample_collection.py
@@ -235,9 +235,7 @@ def update_collection_status(context):
 
 
 def get_collection_status(child_rows):
-	if not child_rows:
-		return "Pending"
-	if all(row.get("status") == "Collected" for row in child_rows):
+	if all(row.get("status") == "Collected" for row in child_rows) or not child_rows:
 		return "Collected"
 	if all(row.get("status") == "Open" for row in child_rows):
 		return "Pending"

--- a/healthcare/healthcare/doctype/sample_collection/test_sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/test_sample_collection.py
@@ -5,7 +5,7 @@ import frappe
 
 from healthcare.healthcare.doctype.sample_collection.sample_collection import (
 	SampleCollection,
-	update_collection_status,
+	get_collection_status,
 )
 from healthcare.tests.utils import HealthcareTestSuite
 
@@ -13,7 +13,7 @@ from healthcare.tests.utils import HealthcareTestSuite
 class TestSampleCollection(HealthcareTestSuite):
 	def test_validate_status_handles_all_collection_states(self):
 		test_cases = [
-			([], "Pending"),
+			([], "Collected"),
 			([frappe._dict({"status": "Open"})], "Pending"),
 			([frappe._dict({"status": "Collected"})], "Collected"),
 			([frappe._dict({"status": "Collected"}), frappe._dict({"status": "Open"})], "Partly Collected"),
@@ -25,9 +25,9 @@ class TestSampleCollection(HealthcareTestSuite):
 				SampleCollection.validate(doc)
 				self.assertEqual(doc.status, expected_status)
 
-	def test_update_collection_status_handles_all_collection_states(self):
+	def test_get_collection_status_handles_all_collection_states(self):
 		test_cases = [
-			([], "Pending"),
+			([], "Collected"),
 			([frappe._dict({"status": "Open"})], "Pending"),
 			([frappe._dict({"status": "Collected"})], "Collected"),
 			([frappe._dict({"status": "Collected"}), frappe._dict({"status": "Open"})], "Partly Collected"),
@@ -35,18 +35,4 @@ class TestSampleCollection(HealthcareTestSuite):
 
 		for child_rows, expected_status in test_cases:
 			with self.subTest(child_rows=child_rows, expected_status=expected_status):
-				context = frappe._dict(sample_collection="SC-TEST-0001")
-				original_get_all = frappe.db.get_all
-				original_set_value = frappe.db.set_value
-				set_value_calls = []
-				try:
-					frappe.db.get_all = lambda *args, **kwargs: child_rows
-					frappe.db.set_value = lambda *args: set_value_calls.append(args)
-					update_collection_status(context)
-					self.assertEqual(
-						set_value_calls,
-						[("Sample Collection", context.sample_collection, "status", expected_status)],
-					)
-				finally:
-					frappe.db.get_all = original_get_all
-					frappe.db.set_value = original_set_value
+				self.assertEqual(get_collection_status(child_rows), expected_status)

--- a/healthcare/healthcare/doctype/sample_collection/test_sample_collection.py
+++ b/healthcare/healthcare/doctype/sample_collection/test_sample_collection.py
@@ -1,9 +1,52 @@
 # Copyright (c) 2015, ESS and Contributors
 # See license.txt
 
+import frappe
 
+from healthcare.healthcare.doctype.sample_collection.sample_collection import (
+	SampleCollection,
+	update_collection_status,
+)
 from healthcare.tests.utils import HealthcareTestSuite
 
 
 class TestSampleCollection(HealthcareTestSuite):
-	pass
+	def test_validate_status_handles_all_collection_states(self):
+		test_cases = [
+			([], "Pending"),
+			([frappe._dict({"status": "Open"})], "Pending"),
+			([frappe._dict({"status": "Collected"})], "Collected"),
+			([frappe._dict({"status": "Collected"}), frappe._dict({"status": "Open"})], "Partly Collected"),
+		]
+
+		for child_rows, expected_status in test_cases:
+			with self.subTest(child_rows=child_rows, expected_status=expected_status):
+				doc = frappe._dict(observation_sample_collection=child_rows, status=None)
+				SampleCollection.validate(doc)
+				self.assertEqual(doc.status, expected_status)
+
+	def test_update_collection_status_handles_all_collection_states(self):
+		test_cases = [
+			([], "Pending"),
+			([frappe._dict({"status": "Open"})], "Pending"),
+			([frappe._dict({"status": "Collected"})], "Collected"),
+			([frappe._dict({"status": "Collected"}), frappe._dict({"status": "Open"})], "Partly Collected"),
+		]
+
+		for child_rows, expected_status in test_cases:
+			with self.subTest(child_rows=child_rows, expected_status=expected_status):
+				context = frappe._dict(sample_collection="SC-TEST-0001")
+				original_get_all = frappe.db.get_all
+				original_set_value = frappe.db.set_value
+				set_value_calls = []
+				try:
+					frappe.db.get_all = lambda *args, **kwargs: child_rows
+					frappe.db.set_value = lambda *args: set_value_calls.append(args)
+					update_collection_status(context)
+					self.assertEqual(
+						set_value_calls,
+						[("Sample Collection", context.sample_collection, "status", expected_status)],
+					)
+				finally:
+					frappe.db.get_all = original_get_all
+					frappe.db.set_value = original_set_value


### PR DESCRIPTION
Issue Description:-
When a Sample Collection document is created and none of its child samples have been collected yet, the parent document status was showing Partly Collected instead of Pending.

Expected behavior:
        - if no samples are collected: Pending
        - if some samples are collected: Partly Collected
        - if all samples are collected: Collected

Actual behavior:

- if at least one child row was not Collected, the parent status logic defaulted to Partly Collected
- this incorrectly included the “nothing collected yet” case
- This also caused confusion in related flows like creating observations from service requests, because the document lifecycle no longer matched the allowed/expected status sequence.

Fix Applied:-
Updated the status calculation in sample_collection.py in two places:
      validate()
      update_collection_status()

The logic is now:

- Collected if all child rows are Collected
- Pending if all child rows are Open
- Partly Collected otherwise


Flow After Fix:-

- A Sample Collection document is created.
- If every sample row is still Open, parent status remains Pending.
- When one or more sample rows become collected while others are still open, parent status becomes Partly Collected.
- When every sample row becomes Collected, parent status becomes Collected.