### PR TITLE
fix:every treamtment plan is listing without any filtering in patient…

### DIFF
--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -390,12 +390,28 @@ frappe.ui.form.on("Patient Encounter", {
 			args: { encounter: frm.doc },
 			freeze: true,
 			freeze_message: __("Fetching Treatment Plans"),
-			callback: function () {
+			callback: function (r) {
+				let applicable_plans = (r.message || []).map((plan) => plan.name);
+
+				if (!applicable_plans.length) {
+					frappe.msgprint(
+						__(
+							"No Treatment Plan Templates match this patient's age, gender, or diagnosis.",
+						),
+					);
+					return;
+				}
+
 				new frappe.ui.form.MultiSelectDialog({
 					doctype: "Treatment Plan Template",
 					target: this.cur_frm,
 					setters: {
 						medical_department: "",
+					},
+					get_query() {
+						return {
+							filters: { name: ["in", applicable_plans] },
+						};
 					},
 					action(selections) {
 						frappe


### PR DESCRIPTION
In patient encounter , while clicking on the treatment plan template every treament plan is listing in the pop , but it should be list according to only the patient age , gender , symptoms and diagnosis

bug : here the python file returning filtered data correctly , but the js is failing due to no parameters in call back function

Capture the server response (r) and extract the names of the plans it already validated (applicable_plans).
If nothing qualifies, show a message instead of opening an empty/misleading picker.
Pass a get_query() to MultiSelectDialog that restricts the underlying list query to name in [...applicable_plans], on top of the existing medical_department setter. MultiSelectDialog natively supports get_query (confirmed in frappe/public/js/frappe/form/multi_select_dialog.js), so this doesn't require touching the dialog widget itself — it just uses a hook that was available but unused.