### PR TITLE
fix: apply treatment plan filters

### DIFF
--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -390,12 +390,28 @@ frappe.ui.form.on("Patient Encounter", {
 			args: { encounter: frm.doc },
 			freeze: true,
 			freeze_message: __("Fetching Treatment Plans"),
-			callback: function () {
+			callback: function (r) {
+				let applicable_plans = (r.message || []).map(plan => plan.name);
+
+				if (!applicable_plans.length) {
+					frappe.msgprint(
+						__(
+							"No Treatment Plan Templates match this patient's age, gender, or diagnosis.",
+						),
+					);
+					return;
+				}
+
 				new frappe.ui.form.MultiSelectDialog({
 					doctype: "Treatment Plan Template",
 					target: this.cur_frm,
 					setters: {
 						medical_department: "",
+					},
+					get_query() {
+						return {
+							filters: { name: ["in", applicable_plans] },
+						};
 					},
 					action(selections) {
 						frappe


### PR DESCRIPTION
Issue: 
<img width="1852" height="903" alt="treamentplanfixedimage" src="https://github.com/user-attachments/assets/e0fb91ed-ac8c-4e40-af94-2e8143681670" />

In patient encounter the treament plan on click button , it show a list of all templates without filtering based on the patient age , diagnosis , gender 

the bug: Inside the js function the call back function missing a paramereter due to that its not catching the server filtered data 

callback: function (r) now captures the server response instead of discarding it, and pulls applicable_plans (the names of templates the backend already filtered by age/gender/diagnosis) out of r.message.
Added a get_query() on the MultiSelectDialog restricting it to name in [...applicable_plans], on top of the existing medical_department setter.
If nothing qualifies, shows a message instead of opening an unrestricted picker.
