### PR TITLE
fix(healthcare): pass uom and qty to healthcare service price lookup

### DIFF
--- a/healthcare/healthcare/custom_doctype/sales_invoice.py
+++ b/healthcare/healthcare/custom_doctype/sales_invoice.py
@@ -17,6 +17,8 @@ class SalesInvoiceMixin:
 			price_list, price_list_currency = frappe.db.get_values(
 				"Price List", {"selling": 1}, ["name", "currency"]
 			)[0]
+			stock_uom = frappe.db.get_value("Item", checked_item.get("item"), "stock_uom")
+			requested_qty = flt(checked_item.get("qty")) or 1
 			ctx: ItemDetailsCtx = ItemDetailsCtx(
 				{
 					"doctype": "Sales Invoice",
@@ -28,6 +30,8 @@ class SalesInvoiceMixin:
 					"currency": self.currency or price_list_currency,
 					"plc_conversion_rate": 1.0,
 					"conversion_rate": 1.0,
+					"qty": requested_qty,
+					"uom": stock_uom,
 				}
 			)
 			item_details = get_item_details(ctx)


### PR DESCRIPTION
Issue description: 

Healthcare Service items added through Sales Invoice -> Get Items From -> Healthcare Services were being inserted with zero rate even though valid Item Price records existed. 

The custom pricing call to get_item_details() did not include the full pricing context required for these items. 

Fix applied: 

- Updated set_healthcare_services to fetch the item stock UOM and pass both uom and qty = 1 into ItemDetailsCtx before calling get_item_details(). 

- This preserves the existing invoice row quantity behavior while allowing ERPNext to match the correct Item Price and populate the proper rate.

Test Case After Fix:
1. Go to Sales Invoice.
2. Select the patient, customer will be autofetch.
3. Click on Get Items From -> Healthcare Services.
4. Select the items and click on Add button.
5. Items will be inserted to sales invoice item table with proper qty and rates.
6. If step 5 is successful, then the test case is passed.

Closes issue: #1140 