### PR TITLE
fix(therapy): practitioner mapping when creating Therapy Session from  Service Request or Therapy Plan

### DIFF
--- a/healthcare/healthcare/doctype/therapy_plan/therapy_plan.py
+++ b/healthcare/healthcare/doctype/therapy_plan/therapy_plan.py
@@ -69,6 +69,7 @@ def make_therapy_session(
 	service_request: str | None = None,
 	practitioner: str | None = None,
 ) -> dict:
+	tp_doc = None
 	if not service_request and therapy_plan:
 		tp_doc = frappe.get_cached_doc("Therapy Plan", therapy_plan)
 		service_request = frappe.db.exists(
@@ -98,6 +99,11 @@ def make_therapy_session(
 			_("Therapy Plan is required to create Therapy Session"),
 			title=_("Therapy Plan Required"),
 		)
+
+	if not tp_doc and therapy_plan:
+		tp_doc = frappe.get_cached_doc("Therapy Plan", therapy_plan)
+
+	practitioner = practitioner or (sr_doc.practitioner if sr_doc else None) or tp_doc.practitioner
 
 	therapy_type = frappe.get_doc("Therapy Type", therapy_type)
 


### PR DESCRIPTION
Issue description:
When a Patient Encounter is submitted for a therapy type, the system creates both a Therapy Plan and a Service Request with the practitioner populated correctly. 

However, when a Therapy Session is later created from either service request or therapy plan , the practitioner is not carried forward because make_therapy_session() only relied on the optional practitioner argument, while the current creation flows do not pass that value.

Fix applied:
Updated make_therapy_session() in therapy_plan.py to resolve practitioner from the source flow when it is not passed explicitly.

Logic change added:
- If the Therapy Session is created from a Service Request, practitioner is fetched from Service Request.practitioner.
- If the Therapy Session is created from a Therapy Plan, practitioner is fetched from Therapy Plan.practitioner.
- If a practitioner is explicitly passed to the method, that value still takes priority.
- Existing department assignment logic remains unchanged and continues to derive department from the resolved practitioner.

Test scenario:
- Create and submit a Patient Encounter with a therapy type and practitioner so that both a Therapy Plan and a Service Request are generated. 
- Then create a Therapy Session from the Service Request and verify the practitioner is fetched from the Service Request. 
- Next, create a Therapy Session from the Therapy Plan and verify the practitioner is fetched from the Therapy Plan, with the practitioner field populated in both flows.