### PR TITLE
fix(healthcare): allow credit note submission for invoiced appointment items

### DIFF
--- a/healthcare/healthcare/utils.py
+++ b/healthcare/healthcare/utils.py
@@ -1035,7 +1035,7 @@ def manage_invoice_submit_cancel(doc, method):
 			if item.get("reference_dt") and item.get("reference_dn"):
 				# TODO check
 				# if frappe.get_meta(item.reference_dt).has_field("invoiced"):
-				set_invoiced(item, method, doc.name)
+				set_invoiced(item, method, doc)
 
 				# update Fee validity with Sales Invoice Reference if exists
 				if item.reference_dt == "Patient Appointment":
@@ -1176,10 +1176,16 @@ def post_transfer_journal_entry_and_update_coverage(sales_invoice):
 		coverage.update_invoice_details(item.qty, item.insurance_coverage_amount)
 
 
-def set_invoiced(item, method, ref_invoice=None):
+def set_invoiced(item, method, sales_invoice=None):
+	ref_invoice = sales_invoice.name if sales_invoice else None
+	is_return = bool(sales_invoice and sales_invoice.is_return)
+
 	invoiced = False
 	if method == "on_submit":
-		validate_invoiced_on_submit(item)
+		if not is_return:
+			validate_invoiced_on_submit(item)
+		invoiced = True
+	elif method == "on_cancel" and is_return:
 		invoiced = True
 
 	if item.reference_dt == "Clinical Procedure":
@@ -1198,6 +1204,10 @@ def set_invoiced(item, method, ref_invoice=None):
 		else:
 			dt_from_appointment = "Patient Encounter"
 		manage_doc_for_appointment(dt_from_appointment, item.reference_dn, invoiced)
+		if is_return:
+			if method == "on_submit":
+				return
+			ref_invoice = frappe.db.get_value("Patient Appointment", item.reference_dn, "ref_sales_invoice")
 		frappe.db.set_value("Patient Appointment", item.reference_dn, "ref_sales_invoice", ref_invoice)
 
 	elif item.reference_dt == "Lab Prescription":


### PR DESCRIPTION
Issue Description
Submitting a credit note from a Sales Invoice that contains Patient Appointment items was failing with:
The item referenced by Patient Appointment - HLC-APP-2026-00221 is already invoiced

This happened because manage_invoice_submit_cancel called set_invoiced with only doc.name, and set_invoiced always treated on_submit like a fresh invoice submission.

During return invoice submit, it re-ran validate_invoiced_on_submit(item), which correctly saw the linked appointment was already invoiced by the original invoice and threw the error. The flow also lacked enough invoice context to distinguish a normal invoice from a return invoice without extra DB work.

Changes Applied:-
- Updated manage_invoice_submit_cancel in utils.py to pass the full Sales Invoice doc into set_invoiced instead of only doc.name.
- Refactored set_invoiced in utils.py to use the invoice doc context directly.
- Added return-invoice handling using sales_invoice.is_return.
- Skipped validate_invoiced_on_submit(item) when the submitted invoice is a return, so credit note submission no longer re-fails on already invoiced appointment references.
- Preserved appointment invoiced state on return cancel by keeping invoiced = True for on_cancel of return invoices.
- Prevented return invoice submit from overwriting Patient Appointment.ref_sales_invoice.
- On return cancel, preserved the existing appointment ref_sales_invoice instead of clearing or replacing it.