### PR TITLE
fix(patient-appointment): keep Patient Appointment print action working on Frappe develop and version-16

### DIFF
--- a/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/healthcare/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -1428,6 +1428,7 @@ let make_payment = function (frm, automate_invoicing) {
 	}
 
 	function show_payment_dialog(frm, fields) {
+		const supports_icon_button = Boolean(frappe.ui?.button?.dress);
 		let d = new frappe.ui.Dialog({
 			title: "Enter Payment Details",
 			fields: fields,
@@ -1466,9 +1467,11 @@ let make_payment = function (frm, automate_invoicing) {
 					},
 				});
 			},
-			secondary_action_label: __(`<svg class="icon  icon-sm" style="">
-				<use class="" href="#icon-printer"></use>
-			</svg>`),
+			secondary_action_label: supports_icon_button
+				? __("Print")
+				: __(`<svg class="icon  icon-sm" style="">
+					<use class="" href="#icon-printer"></use>
+				</svg>`),
 			secondary_action() {
 				window.open(
 					"/app/print/Sales Invoice/" + frm.doc.ref_sales_invoice,
@@ -1477,6 +1480,14 @@ let make_payment = function (frm, automate_invoicing) {
 				d.hide();
 			},
 		});
+		if (supports_icon_button) {
+			const secondary_btn = d.get_secondary_btn();
+			frappe.ui.button.dress(secondary_btn, {
+				icon: "printer",
+				title: __("Print"),
+			});
+			secondary_btn.attr("title", __("Print"));
+		}
 		d.fields_dict["mode_of_payment"].df.onchange = () => {
 			if (d.get_value("mode_of_payment")) {
 				frm.set_value("mode_of_payment", d.get_value("mode_of_payment"));


### PR DESCRIPTION
In the Patient Appointment payment dialog, the secondary print action was defined using inline SVG as secondary_action_label.
That worked on Frappe version-16, because Dialog.set_secondary_action_label() renders the label with .html(...).

It breaks on current Frappe develop after the dialog footer button refactor in commit 7aa1006736 from July 31, 2026:
feat(ui): migrate modal footer buttons to espresso (#41444)

After that change, dialog button labels are treated as text via the new button dressing flow, so the raw SVG label is shown as literal markup instead of rendering as an icon.

Changes Applied:-

1. In patient_appointment.js :-

    - added a small capability check:const supports_icon_button = Boolean(frappe.ui?.button?.dress);
    - changed secondary_action_label to:
                 - use __("Print") when the newer button API exists
                - fall back to the original inline SVG when it does not
    - after dialog creation, added:
           - frappe.ui.button.dress(d.get_secondary_btn(), { icon: "printer", title: __("Print") })
          - only when supports_icon_button is available

Flow On Frappe Develop:-
- supports_icon_button is true
- dialog label is set to plain Print
- after dialog creation, the secondary button is dressed into an icon-only printer button
- result:no raw SVG text appears
- print button matches the expected modern UI

Flow On Frappe Version-16

- supports_icon_button is false
- dialog keeps using the original inline SVG label
- frappe.ui.button.dress(...) is not called
- result:old behavior is preserved
- no regression for instances still on Frappe version-16

Before:-
<img width="656" height="453" alt="image" src="https://github.com/user-attachments/assets/9316f451-8009-4186-8087-a64c11a4ae6d" />


After:-
<img width="621" height="409" alt="image" src="https://github.com/user-attachments/assets/3eb52213-2882-4bca-9dbd-d403fc5d32d0" />


After clicking create invoice, print icon enabled:-
<img width="652" height="480" alt="image" src="https://github.com/user-attachments/assets/f1dd13f6-4be9-4c3c-850a-386b3ee7d692" />


It then navigates to preview print format display