### PR TITLE
fix(a11y): add alt text to patient/practitioner photo images

### DIFF
--- a/patient_portal/src/components/AppointmentModel.vue
+++ b/patient_portal/src/components/AppointmentModel.vue
@@ -103,7 +103,7 @@
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:[&>section]:h-full">
 					<section class="md:col-start-1 md:row-start-1">
 						<div class="flex items-start gap-4 px-2">
-							<img v-if="selectedAppointment.patient_image" :src="selectedAppointment.patient_image"
+							<img v-if="selectedAppointment.patient_image" :src="selectedAppointment.patient_image" alt=""
 								class="w-20 h-20 rounded-full object-cover border" />
 							<div v-else
 								class="w-20 h-20 rounded-full flex items-center justify-center text-gray-700 text-2xl font-semibold border">
@@ -136,7 +136,7 @@
 					<section class="md:col-start-1 md:row-start-2">
 						<div class="flex items-start gap-4 px-2">
 							<img v-if="selectedAppointment.practitioner_image"
-								:src="selectedAppointment.practitioner_image"
+								:src="selectedAppointment.practitioner_image" alt=""
 								class="w-20 h-20 rounded-full object-cover border" />
 							<div v-else
 								class="w-20 h-20 rounded-full flex items-center justify-center text-gray-700 text-2xl font-semibold border">

--- a/patient_portal/src/components/BookAppointmentModel.vue
+++ b/patient_portal/src/components/BookAppointmentModel.vue
@@ -49,6 +49,7 @@
 								<img
 									v-if="selectedPractitioner.image"
 									:src="selectedPractitioner.image"
+									alt=""
 									class="w-full h-full rounded-full object-cover bg-gray-100"
 								/>
 								<div

--- a/patient_portal/src/components/DepartmentSelector.vue
+++ b/patient_portal/src/components/DepartmentSelector.vue
@@ -27,7 +27,7 @@
 					class="absolute top-2 right-2 bg-green-500 text-white rounded-full p-1 shadow-md z-20">
 					<FeatherIcon name="check" class="w-4 h-4" />
 				</div>
-				<img v-if="dept.portal_image" :src="dept.portal_image"
+				<img v-if="dept.portal_image" :src="dept.portal_image" alt=""
 					class="w-full h-32 object-cover rounded-t-xl bg-gray-100" />
 				<div v-else
 					class="w-full h-32 flex items-center justify-center rounded-t-xl text-gray-700 text-3xl font-semibold bg-gray-100">

--- a/patient_portal/src/components/DiagnosticModel.vue
+++ b/patient_portal/src/components/DiagnosticModel.vue
@@ -81,8 +81,8 @@
 			<div class="p-4 bg-white rounded-xl shadow-md border space-y-4">
 				<div class="flex items-center gap-4">
 					<!-- Patient Photo -->
-					<img v-if="selectedOrder.patient_image" 
-						:src="selectedOrder.patient_image"
+					<img v-if="selectedOrder.patient_image"
+						:src="selectedOrder.patient_image" alt=""
 						class="w-16 h-16 rounded-full object-cover border" />
 					<div v-else
 						class="w-16 h-16 rounded-full flex items-center justify-center bg-gray-100 text-gray-600 font-bold text-xl">

--- a/patient_portal/src/components/PractitionerSelector.vue
+++ b/patient_portal/src/components/PractitionerSelector.vue
@@ -28,7 +28,7 @@
 					<FeatherIcon name="check" class="w-4 h-4" />
 				</div>
 				<div class="flex flex-col items-center">
-					<img v-if="doc.image" :src="doc.image" class="w-full h-32 object-cover rounded-t-xl bg-gray-100" />
+					<img v-if="doc.image" :src="doc.image" alt="" class="w-full h-32 object-cover rounded-t-xl bg-gray-100" />
 					<div v-else
 						class="w-full h-32 flex items-center justify-center rounded-t-xl text-gray-700 text-3xl font-semibold bg-gray-100">
 						{{ doc.practitioner_name.charAt(0).toUpperCase() }}


### PR DESCRIPTION
## Problem

Five patient/practitioner photos in the patient portal had no `alt` attribute.

## Fix

All five are avatar-next-to-name pairs — the appointment, booking, department, diagnostic, and practitioner-selector cards each already show the person's or department's name as visible text right beside the photo — so `alt=""`, matching the standard avatar-with-adjacent-name convention.
