### PR TITLE
fix(sample-collection): include nested encounter components in sample collection

### DIFF
--- a/healthcare/healthcare/doctype/observation/test_observation.py
+++ b/healthcare/healthcare/doctype/observation/test_observation.py
@@ -9,6 +9,7 @@ from healthcare.healthcare.doctype.healthcare_settings.healthcare_settings impor
 	get_income_account,
 	get_receivable_account,
 )
+from healthcare.healthcare.doctype.service_request.service_request import make_observation
 from healthcare.tests.utils import HealthcareTestSuite
 
 
@@ -178,6 +179,44 @@ class TestObservation(HealthcareTestSuite):
 					"template_dn": observation_template.name,
 					"order_group": encounter.name,
 				},
+			)
+		)
+
+	def test_nested_component_sample_collection_from_encounter(self):
+		grouped_template = frappe.get_doc("Observation Template", "_Test Observation Grouped with Sample")
+		if frappe.db.exists("Observation Template", "_Test Encounter Nested Package"):
+			package = frappe.get_doc("Observation Template", "_Test Encounter Nested Package")
+		else:
+			package = frappe.get_doc(
+				{
+					"doctype": "Observation Template",
+					"observation": "_Test Encounter Nested Package",
+					"item_code": "_Test Encounter Nested Package",
+					"observation_category": "Laboratory",
+					"item_group": "Services",
+					"has_component": 1,
+					"rate": 300,
+					"is_billable": 1,
+					"observation_component": [
+						{"observation_template": grouped_template.name},
+					],
+				}
+			).insert(ignore_permissions=True)
+		patient = self.get_test_patient()
+		encounter = create_patient_encounter(patient, package.name)
+		service_request = frappe.db.get_value(
+			"Service Request",
+			{"patient": patient, "template_dn": package.name, "order_group": encounter.name},
+			"name",
+		)
+
+		sample_collection, doctype = make_observation(service_request)
+
+		self.assertEqual(doctype, "Sample Collection")
+		self.assertTrue(
+			frappe.db.exists(
+				"Observation Sample Collection",
+				{"parent": sample_collection, "observation_template": grouped_template.name},
 			)
 		)
 

--- a/healthcare/healthcare/doctype/observation/test_observation.py
+++ b/healthcare/healthcare/doctype/observation/test_observation.py
@@ -209,6 +209,13 @@ class TestObservation(HealthcareTestSuite):
 			{"patient": patient, "template_dn": package.name, "order_group": encounter.name},
 			"name",
 		)
+		service_request_company = (
+			frappe.db.get_value("Service Request", service_request, "company")
+			or frappe.db.get_value("Patient Encounter", encounter.name, "company")
+			or frappe.defaults.get_user_default("Company")
+			or frappe.defaults.get_user_default("company")
+			or frappe.db.get_single_value("Global Defaults", "default_company")
+		)
 
 		sample_collection, doctype = make_observation(service_request)
 
@@ -219,6 +226,22 @@ class TestObservation(HealthcareTestSuite):
 				{"parent": sample_collection, "observation_template": grouped_template.name},
 			)
 		)
+		observations = frappe.db.get_all(
+			"Observation",
+			filters={"service_request": service_request},
+			fields=["name", "company"],
+		)
+		self.assertTrue(observations)
+		self.assertTrue(all(obs.company == service_request_company for obs in observations))
+		component_observation_company = frappe.db.get_value(
+			"Observation",
+			{
+				"parent_observation": observations[0].name,
+				"observation_template": grouped_template.name,
+			},
+			"company",
+		)
+		self.assertEqual(component_observation_company, service_request_company)
 
 	def test_formula_computes_result(self):
 		self.enable_observation_on_invoice_submit()
@@ -453,6 +476,7 @@ def create_sales_invoice(patient, item):
 def create_patient_encounter(patient, observation_template):
 	patient_encounter = frappe.new_doc("Patient Encounter")
 	patient_encounter.patient = patient
+	patient_encounter.company = "_Test Company"
 	patient_encounter.practitioner = frappe.get_list("Healthcare Practitioner", pluck="name")[0]
 	patient_encounter.appointment_type = "_Test Appointment Type"
 	patient_encounter.encounter_date = getdate()

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -237,6 +237,7 @@ def make_observation(service_request: str, appointment: str | None = None) -> tu
 		return
 
 	service_request = frappe.get_cached_doc("Service Request", service_request)
+	service_request.company = get_service_request_company(service_request)
 
 	if (
 		frappe.db.get_single_value("Healthcare Settings", "process_service_request_only_if_paid")
@@ -288,6 +289,7 @@ def make_observation(service_request: str, appointment: str | None = None) -> tu
 					doc="Patient Encounter",
 					docname=service_request.order_group,
 					parent=observation.name,
+					company=service_request.company,
 				)
 
 		if len(sample_reqd_component_obs) > 0:
@@ -414,6 +416,24 @@ def get_nested_sample_collection_groups(observation_template):
 	return components
 
 
+def get_service_request_company(service_request):
+	if service_request.company:
+		return service_request.company
+
+	if service_request.source_doc and service_request.order_group:
+		source_company = frappe.db.get_value(
+			service_request.source_doc, service_request.order_group, "company"
+		)
+		if source_company:
+			return source_company
+
+	return (
+		frappe.defaults.get_user_default("Company")
+		or frappe.defaults.get_user_default("company")
+		or frappe.db.get_single_value("Global Defaults", "default_company")
+	)
+
+
 def create_sample_collection(patient, service_request, appointment=None, template=None):
 	sample_collection = frappe.new_doc("Sample Collection")
 	sample_collection.patient = patient.name
@@ -451,6 +471,7 @@ def create_observation(service_request, appointment=None):
 	doc.reference_doctype = "Patient Encounter"
 	doc.reference_docname = service_request.order_group
 	doc.service_request = service_request.name
+	doc.company = service_request.company
 	doc.insert()
 	return doc
 

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -275,13 +275,14 @@ def make_observation(service_request: str, appointment: str | None = None) -> tu
 		observation = create_observation(service_request, appointment)
 
 		save_sample_collection = False
+		component_observation_by_template = {}
 		(
 			sample_reqd_component_obs,
 			non_sample_reqd_component_obs,
 		) = get_observation_template_details(service_request.template_dn)
 		if len(non_sample_reqd_component_obs) > 0:
 			for comp in non_sample_reqd_component_obs:
-				add_observation(
+				component_observation_by_template[comp] = add_observation(
 					patient=service_request.patient,
 					template=comp,
 					doc="Patient Encounter",
@@ -310,6 +311,26 @@ def make_observation(service_request: str, appointment: str | None = None) -> tu
 					"status": "Open",
 					"sample_qty": obs_template.sample_qty,
 					"component_observation_parent": observation.name,
+					"service_request": service_request.name,
+				},
+			)
+
+		for component in get_nested_sample_collection_groups(service_request.template_dn):
+			save_sample_collection = True
+			sample_collection.append(
+				"observation_sample_collection",
+				{
+					"observation_template": component.name,
+					"sample": component.sample,
+					"sample_type": component.sample_type,
+					"container_closure_color": component.container_closure_color,
+					"component_observations": json.dumps(set_component_observation_data(component.name)),
+					"uom": component.uom,
+					"status": "Open",
+					"sample_qty": component.sample_qty,
+					"component_observation_parent": component_observation_by_template.get(
+						component.name, observation.name
+					),
 					"service_request": service_request.name,
 				},
 			)
@@ -359,6 +380,38 @@ def make_observation(service_request: str, appointment: str | None = None) -> tu
 		return sample_collection.name, "Sample Collection"
 	elif observation:
 		return observation.name, "Observation"
+
+
+def get_nested_sample_collection_groups(observation_template):
+	_sample_reqd_component_obs, non_sample_reqd_component_obs = get_observation_template_details(
+		observation_template
+	)
+	components = []
+
+	for comp in non_sample_reqd_component_obs:
+		component = frappe.get_cached_value(
+			"Observation Template",
+			comp,
+			[
+				"name",
+				"has_component",
+				"sample",
+				"sample_type",
+				"container_closure_color",
+				"uom",
+				"sample_qty",
+			],
+			as_dict=True,
+		)
+		if component.has_component:
+			sample_reqd_component_obs, _non_sample_reqd_component_obs = get_observation_template_details(
+				component.name
+			)
+			if len(sample_reqd_component_obs) > 0:
+				components.append(component)
+			components.extend(get_nested_sample_collection_groups(component.name))
+
+	return components
 
 
 def create_sample_collection(patient, service_request, appointment=None, template=None):


### PR DESCRIPTION
 Issue Description
  Encounter-based sample collection did not include nested package components.

  Example flow:
  Package Test -> CBC / Lipid Profile -> child components requiring sample collection

  When the package was added from Patient Encounter, sample collection was created only for direct components. If CBC or
  Lipid Profile were grouped components and their child components required sample collection, those nested sample rows
  were missed.

  Sales Invoice flow already handled this correctly, so the issue was specific to encounter/service-request based sample
  collection.

  Fix Applied
  Updated encounter observation sample collection logic in service_request.py.

  Changes applied:

  - Added recursive detection for nested grouped observation templates.
  - When a direct child group like CBC or Lipid Profile contains sample-required child components, the encounter flow
    now adds that group to Observation Sample Collection.

  - Preserved existing direct-component behavior.
  - Kept the existing component_observations payload structure using set_component_observation_data().
  - Added a focused regression test .

  Why
  The previous encounter logic only checked one level of observation components with get_observation_template_details().
  That worked for direct children but skipped nested groups where sample collection was required by grandchildren.

  The fix keeps the existing model intact and only adds the missing recursive handling for nested groups.

Before:-
<img width="1063" height="259" alt="image" src="https://github.com/user-attachments/assets/dc419bf5-f54a-4b1d-a112-a215189511f9" />

After fix:
<img width="1097" height="491" alt="image" src="https://github.com/user-attachments/assets/0026c938-c132-47ef-a31b-7db1aebd132b" />


  Flow After Fix:-
  1. Package test is added in Patient Encounter.
  2. Encounter creates a Service Request for the package.
  3. make_observation() creates the parent package Observation.
  4. Direct non-sample grouped components are created as child Observations.
  5. The new recursive helper checks those child groups.
  6. If a group contains sample-required child components, it is added to Sample Collection.
  7. Sample Collection now shows nested groups like CBC and Lipid Profile with their child sample components available
     in component_observations.