### PR TITLE
fix(discharge-summary): discharge summary naming series when created from inpatient record

### DIFF
--- a/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
+++ b/healthcare/healthcare/doctype/inpatient_record/inpatient_record.py
@@ -709,7 +709,9 @@ def cancel_amend_treatment_counselling(args, treatment_counselling):
 
 
 @frappe.whitelist()
-def make_discharge_summary(source_name, target_doc=None, ignore_permissions=False):
+def make_discharge_summary(
+	source_name: str, target_doc: Document | None = None, ignore_permissions: bool = False
+) -> Document:
 	doclist = get_mapped_doc(
 		"Inpatient Record",
 		source_name,
@@ -719,7 +721,7 @@ def make_discharge_summary(source_name, target_doc=None, ignore_permissions=Fals
 				"field_map": {
 					"name": "inpatient_record",
 				},
-				"field_no_map": ["status", "chief_complaint", "diagnosis"],
+				"field_no_map": ["naming_series", "status", "chief_complaint", "diagnosis"],
 			},
 		},
 		target_doc,


### PR DESCRIPTION
Issue Description:-
  When a Discharge Summary is created from an Inpatient Record using the mapped document flow, it inherits the Inpatient
  Record naming_series. This causes the Discharge Summary to use the inpatient prefix, such as HLC-INP-.YYYY.-, instead
  of its own configured series HLC-DS-.YYYY.-.

  Manually created Discharge Summary records work correctly because they use the doctype default series.

  Fix Applied
  Updated the Inpatient Record to Discharge Summary mapper to exclude naming_series from copied fields. This allows the
  Discharge Summary doctype default naming series to be applied during creation.

Before:
<img width="733" height="266" alt="image" src="https://github.com/user-attachments/assets/0d87fe05-06f3-43e8-a6ae-d12160e9ce38" />

After fix:
<img width="665" height="280" alt="image" src="https://github.com/user-attachments/assets/ae4bcfb1-6c87-40c2-b325-43f228925866" />
